### PR TITLE
feat: add GitHub/npm links to Skills and MCP Tools sections

### DIFF
--- a/src/components/McpTools/McpTools.module.css
+++ b/src/components/McpTools/McpTools.module.css
@@ -22,6 +22,38 @@
   margin-bottom: 48px;
 }
 
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 48px;
+  flex-wrap: wrap;
+}
+
+.titleRow .sectionTitle {
+  margin-bottom: 0;
+}
+
+.titleLinks {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.externalLink {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+
+.externalLink:hover {
+  text-decoration: underline;
+}
+
 /* Tabs */
 .tabs {
   display: flex;

--- a/src/components/McpTools/McpTools.tsx
+++ b/src/components/McpTools/McpTools.tsx
@@ -111,7 +111,27 @@ function McpTools() {
   return (
     <section className={styles.section}>
       <p className={styles.sectionLabel}>MCP Tools</p>
-      <h2 className={styles.sectionTitle}>25 个标准化工具，覆盖语雀全部核心能力</h2>
+      <div className={styles.titleRow}>
+        <h2 className={styles.sectionTitle}>25 个标准化工具，覆盖语雀全部核心能力</h2>
+        <div className={styles.titleLinks}>
+          <a
+            className={styles.externalLink}
+            href="https://github.com/chen201724/yuque-mcp-server"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on GitHub →
+          </a>
+          <a
+            className={styles.externalLink}
+            href="https://www.npmjs.com/package/yuque-mcp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            npm →
+          </a>
+        </div>
+      </div>
 
       <div className={styles.tabs}>
         {categories.map((cat) => (

--- a/src/components/Skills/Skills.module.css
+++ b/src/components/Skills/Skills.module.css
@@ -22,6 +22,31 @@
   margin-bottom: 16px;
 }
 
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.titleRow .sectionTitle {
+  margin-bottom: 0;
+}
+
+.externalLink {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+
+.externalLink:hover {
+  text-decoration: underline;
+}
+
 .sectionDesc {
   text-align: center;
   color: var(--color-text-secondary);
@@ -85,6 +110,20 @@
   font-size: 12px;
   font-weight: 500;
   border: 1px solid rgba(0, 185, 107, 0.15);
+}
+
+.cardLink {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.cardLink:hover {
+  text-decoration: underline;
 }
 
 @media (max-width: 960px) {

--- a/src/components/Skills/Skills.tsx
+++ b/src/components/Skills/Skills.tsx
@@ -6,36 +6,42 @@ const skills = [
     title: '智能搜索与问答',
     desc: '"我记得之前写过一篇关于 xxx 的文档" → 秒找到并总结关键内容。',
     tags: ['search_docs', 'get_doc_content', 'ai_summarize'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/smart-search',
   },
   {
     icon: '📝',
     title: '会议纪要归档',
     desc: '开完会丢给 AI，自动整理格式并归档到知识库对应目录。',
     tags: ['create_doc', 'update_doc', 'move_to_repo'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/meeting-notes',
   },
   {
     icon: '📊',
     title: '周报生成',
     desc: '汇总本周文档动态，一键生成结构化周报草稿。',
     tags: ['list_recent_docs', 'get_doc_content', 'create_doc'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/weekly-report',
   },
   {
     icon: '📐',
     title: '技术方案撰写',
     desc: '给个需求描述，按团队模板自动生成方案骨架，省去重复排版。',
     tags: ['get_template', 'create_doc', 'update_doc'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/tech-design',
   },
   {
     icon: '🎒',
     title: '新人入职知识包',
     desc: '自动整理团队核心文档，生成入职阅读指南和学习路径。',
     tags: ['list_repo_docs', 'get_doc_content', 'create_doc'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/onboarding-guide',
   },
   {
     icon: '📈',
     title: '团队知识月报',
     desc: '月底自动统计文档产出和知识沉淀趋势，量化团队知识资产。',
     tags: ['list_group_repos', 'list_recent_docs', 'create_doc'],
+    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/knowledge-report',
   },
 ]
 
@@ -43,7 +49,17 @@ function Skills() {
   return (
     <section className={styles.section}>
       <p className={styles.sectionLabel}>Skills</p>
-      <h2 className={styles.sectionTitle}>场景化 AI 工作流</h2>
+      <div className={styles.titleRow}>
+        <h2 className={styles.sectionTitle}>场景化 AI 工作流</h2>
+        <a
+          className={styles.externalLink}
+          href="https://github.com/chen201724/yuque-skills"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View on GitHub →
+        </a>
+      </div>
       <p className={styles.sectionDesc}>
         每个 Skill 都是一个精心编排的工作流，将多个 Tools 组合成开箱即用的解决方案。
       </p>
@@ -58,6 +74,14 @@ function Skills() {
                 <span key={t} className={styles.tag}>{t}</span>
               ))}
             </div>
+            <a
+              className={styles.cardLink}
+              href={s.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              查看详情 →
+            </a>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Changes

### Skills 区域
- 标题旁新增 **View on GitHub** 链接 → [yuque-skills](https://github.com/chen201724/yuque-skills)
- 每个 Skill 卡片新增 **查看详情** 链接，指向对应 skill 目录：
  - smart-search / meeting-notes / weekly-report / tech-design / onboarding-guide / knowledge-report

### MCP Tools 区域
- 标题旁新增 **View on GitHub** 链接 → [yuque-mcp-server](https://github.com/chen201724/yuque-mcp-server)
- 标题旁新增 **npm** 链接 → [yuque-mcp](https://www.npmjs.com/package/yuque-mcp)

### 样式
- 语雀绿色 (`#00B96B`)，hover 显示下划线，新窗口打开
- 响应式布局兼容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external links to GitHub and npm in the McpTools header
  * Added GitHub link to the Skills section header
  * Added detail action links to individual skill cards

* **Style**
  * Improved header layout with enhanced spacing and visual hierarchy
  * Added interactive hover effects to links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->