### PR TITLE
chore: update org links from chen201724 to yuque

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "语雀 AI 生态 Plugin Marketplace — MCP Tools, Skills, and Agents for Yuque",
   "owner": {
-    "name": "chen201724",
+    "name": "yuque",
     "email": "willchen.babydog@gmail.com"
   },
   "plugins": [
@@ -13,11 +13,11 @@
       "description": "语雀知识库 AI 集成 — 25 MCP Tools + 6 Skills + 专业 Agent",
       "version": "1.0.0",
       "author": {
-        "name": "chen201724"
+        "name": "yuque"
       },
       "source": {
         "source": "github",
-        "repo": "chen201724/yuque-plugin"
+        "repo": "yuque/yuque-plugin"
       },
       "category": "productivity"
     }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN
 ## 📦 Links
 
 - [npm: yuque-mcp](https://www.npmjs.com/package/yuque-mcp)
-- [Website](https://chen201724.github.io/yuque-ecosystem/)
+- [Website](https://yuque.github.io/yuque-ecosystem/)
 
 ## License
 
-MIT © chen201724
+MIT © yuque

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -33,7 +33,7 @@ function Footer() {
     <footer className={styles.footer}>
       <div className={styles.links}>
         <a
-          href="https://github.com/chen201724/yuque-ecosystem"
+          href="https://github.com/yuque/yuque-ecosystem"
           target="_blank"
           rel="noopener noreferrer"
           className={styles.link}
@@ -61,7 +61,7 @@ function Footer() {
       <span id="busuanzi_value_site_pv" style={{ display: 'none' }} />
       <span id="busuanzi_value_site_uv" style={{ display: 'none' }} />
       <p className={styles.credit}>
-        Built with <span className={styles.heart}>❤️</span> by chen201724
+        Built with <span className={styles.heart}>❤️</span> by yuque
       </p>
     </footer>
   )

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -28,7 +28,7 @@ function Hero() {
             Get Started
           </a>
           <a
-            href="https://github.com/chen201724/yuque-ecosystem"
+            href="https://github.com/yuque/yuque-ecosystem"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.btnSecondary}

--- a/src/components/McpTools/McpTools.tsx
+++ b/src/components/McpTools/McpTools.tsx
@@ -116,7 +116,7 @@ function McpTools() {
         <div className={styles.titleLinks}>
           <a
             className={styles.externalLink}
-            href="https://github.com/chen201724/yuque-mcp-server"
+            href="https://github.com/yuque/yuque-mcp-server"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/src/components/Plugin/Plugin.tsx
+++ b/src/components/Plugin/Plugin.tsx
@@ -14,7 +14,7 @@ function Plugin() {
         <h2 className={styles.sectionTitle}>一键集成，开箱即用</h2>
         <a
           className={styles.externalLink}
-          href="https://github.com/chen201724/yuque-plugin"
+          href="https://github.com/yuque/yuque-plugin"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -48,7 +48,7 @@ function Plugin() {
           </p>
           <div className={styles.codeBlock}>
             <span className={styles.codeComment}># 安装 yuque-plugin</span>{'\n'}
-            claude plugin add github:chen201724/yuque-plugin
+            claude plugin add github:yuque/yuque-plugin
           </div>
         </div>
 

--- a/src/components/Skills/Skills.tsx
+++ b/src/components/Skills/Skills.tsx
@@ -6,42 +6,42 @@ const skills = [
     title: '智能搜索与问答',
     desc: '"我记得之前写过一篇关于 xxx 的文档" → 秒找到并总结关键内容。',
     tags: ['search_docs', 'get_doc_content', 'ai_summarize'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/smart-search',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/smart-search',
   },
   {
     icon: '📝',
     title: '会议纪要归档',
     desc: '开完会丢给 AI，自动整理格式并归档到知识库对应目录。',
     tags: ['create_doc', 'update_doc', 'move_to_repo'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/meeting-notes',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/meeting-notes',
   },
   {
     icon: '📊',
     title: '周报生成',
     desc: '汇总本周文档动态，一键生成结构化周报草稿。',
     tags: ['list_recent_docs', 'get_doc_content', 'create_doc'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/weekly-report',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/weekly-report',
   },
   {
     icon: '📐',
     title: '技术方案撰写',
     desc: '给个需求描述，按团队模板自动生成方案骨架，省去重复排版。',
     tags: ['get_template', 'create_doc', 'update_doc'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/tech-design',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/tech-design',
   },
   {
     icon: '🎒',
     title: '新人入职知识包',
     desc: '自动整理团队核心文档，生成入职阅读指南和学习路径。',
     tags: ['list_repo_docs', 'get_doc_content', 'create_doc'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/onboarding-guide',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/onboarding-guide',
   },
   {
     icon: '📈',
     title: '团队知识月报',
     desc: '月底自动统计文档产出和知识沉淀趋势，量化团队知识资产。',
     tags: ['list_group_repos', 'list_recent_docs', 'create_doc'],
-    link: 'https://github.com/chen201724/yuque-skills/tree/main/skills/knowledge-report',
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/knowledge-report',
   },
 ]
 
@@ -53,7 +53,7 @@ function Skills() {
         <h2 className={styles.sectionTitle}>场景化 AI 工作流</h2>
         <a
           className={styles.externalLink}
-          href="https://github.com/chen201724/yuque-skills"
+          href="https://github.com/yuque/yuque-skills"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
## Summary

仓库从 `chen201724` 组织迁移到 `yuque` 组织后，更新所有相关链接和引用。

## Changes

- `chen201724/yuque-ecosystem` → `yuque/yuque-ecosystem`
- `chen201724/yuque-mcp-server` → `yuque/yuque-mcp-server`
- `chen201724/yuque-skills` → `yuque/yuque-skills`
- `chen201724/yuque-plugin` → `yuque/yuque-plugin`
- `chen201724.github.io/yuque-ecosystem` → `yuque.github.io/yuque-ecosystem`
- Author name `chen201724` → `yuque`

## Files Modified

- `README.md` - Website link & copyright
- `.claude-plugin/marketplace.json` - Plugin author name & repo
- `src/components/Footer/Footer.tsx` - GitHub link & author
- `src/components/Hero/Hero.tsx` - GitHub link
- `src/components/McpTools/McpTools.tsx` - MCP server GitHub link
- `src/components/Plugin/Plugin.tsx` - Plugin GitHub link & install command
- `src/components/Skills/Skills.tsx` - All skills GitHub links