### PR TITLE
docs: add Upgrade section to homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import McpTools from './components/McpTools/McpTools'
 import Skills from './components/Skills/Skills'
 import Plugin from './components/Plugin/Plugin'
 import QuickStart from './components/QuickStart/QuickStart'
+import Upgrade from './components/Upgrade/Upgrade'
 import Footer from './components/Footer/Footer'
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
       <Skills />
       <Plugin />
       <QuickStart />
+      <Upgrade />
       <Footer />
     </>
   )

--- a/src/components/Upgrade/Upgrade.module.css
+++ b/src/components/Upgrade/Upgrade.module.css
@@ -1,0 +1,132 @@
+.section {
+  padding: 100px 24px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.sectionLabel {
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-primary);
+  margin-bottom: 16px;
+}
+
+.sectionTitle {
+  text-align: center;
+  font-size: clamp(28px, 4vw, 40px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 16px;
+}
+
+.sectionDesc {
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  margin-bottom: 48px;
+}
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.step {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.stepNumber {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(0, 185, 107, 0.1);
+  border: 1px solid rgba(0, 185, 107, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.stepContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.stepTitle {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.stepDesc {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.codeBlock {
+  position: relative;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 16px 20px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--color-text);
+  overflow-x: auto;
+  white-space: pre;
+  max-width: 100%;
+  word-break: break-all;
+}
+
+.codeComment {
+  color: var(--color-text-muted);
+}
+
+.codeHighlight {
+  color: var(--color-primary);
+}
+
+.divider {
+  width: 1px;
+  height: 24px;
+  background: var(--color-border);
+  margin-left: 17px;
+}
+
+@media (max-width: 640px) {
+  .section {
+    padding: 60px 16px;
+  }
+  .step {
+    flex-direction: column;
+    gap: 12px;
+  }
+  .stepTitle {
+    font-size: 15px;
+  }
+  .stepDesc {
+    font-size: 13px;
+  }
+  .codeBlock {
+    font-size: 11px;
+    padding: 12px 14px;
+    border-radius: 8px;
+  }
+  .divider {
+    margin-left: 0;
+    width: 24px;
+    height: 1px;
+  }
+}

--- a/src/components/Upgrade/Upgrade.tsx
+++ b/src/components/Upgrade/Upgrade.tsx
@@ -1,0 +1,73 @@
+import styles from './Upgrade.module.css'
+
+function Upgrade() {
+  return (
+    <section className={styles.section}>
+      <p className={styles.sectionLabel}>Upgrade</p>
+      <h2 className={styles.sectionTitle}>🔄 更新 / Upgrade</h2>
+      <p className={styles.sectionDesc}>
+        保持你的语雀 AI 工具始终是最新版本。
+      </p>
+      <div className={styles.steps}>
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>1</div>
+          <div className={styles.stepContent}>
+            <h3 className={styles.stepTitle}>更新 Plugin（Skills &amp; Agent）</h3>
+            <p className={styles.stepDesc}>
+              当我们发布新版本的 Skills 或 Agent 时，你可以通过以下方式更新：
+            </p>
+            <div className={styles.codeBlock}>
+              <span className={styles.codeComment}># 更新 Marketplace 目录</span>{'\n'}
+              /plugin marketplace update{'\n'}{'\n'}
+              <span className={styles.codeComment}># 重新安装 Plugin 以获取最新版本</span>{'\n'}
+              /plugin install yuque@yuque-ecosystem
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.divider} />
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>2</div>
+          <div className={styles.stepContent}>
+            <h3 className={styles.stepTitle}>更新 MCP Server</h3>
+            <p className={styles.stepDesc}>
+              MCP Server（yuque-mcp）通过 <code>npx -y yuque-mcp</code> 运行，每次启动时会自动检查并使用最新版本，无需手动更新。
+            </p>
+            <div className={styles.codeBlock}>
+              <span className={styles.codeComment}># 如需指定版本</span>{'\n'}
+              {'{'}{'\n'}
+              {'  '}"mcpServers": {'{'}{'\n'}
+              {'    '}"yuque": {'{'}{'\n'}
+              {'      '}"command": "npx",{'\n'}
+              {'      '}"args": ["-y", "<span className={styles.codeHighlight}>yuque-mcp@1.0.0</span>"]{'\n'}
+              {'    '}{'}'}{'\n'}
+              {'  '}{'}'}{'\n'}
+              {'}'}
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.divider} />
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>3</div>
+          <div className={styles.stepContent}>
+            <h3 className={styles.stepTitle}>查看版本</h3>
+            <p className={styles.stepDesc}>
+              随时确认你正在使用的版本。
+            </p>
+            <div className={styles.codeBlock}>
+              <span className={styles.codeComment}># Plugin 版本</span>{'\n'}
+              查看 /plugin 界面的 Installed tab{'\n'}{'\n'}
+              <span className={styles.codeComment}># MCP Server 版本</span>{'\n'}
+              npx yuque-mcp --version
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default Upgrade


### PR DESCRIPTION
在官网 QuickStart 后面添加了 Upgrade 组件，包含：

- 更新 Plugin（Skills & Agent）的步骤
- 更新 MCP Server 的说明
- 查看版本的方法

样式复用 QuickStart 的设计风格，保持一致性。