### PR TITLE
feat(Skills): 添加个人/团队场景切换 Tab

### DIFF
--- a/src/components/Skills/Skills.module.css
+++ b/src/components/Skills/Skills.module.css
@@ -52,13 +52,70 @@
   color: var(--color-text-secondary);
   font-size: 16px;
   max-width: 560px;
-  margin: 0 auto 64px;
+  margin: 0 auto 40px;
 }
 
+/* Tab switcher */
+.tabWrapper {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.tabContainer {
+  display: inline-flex;
+  border-radius: 12px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  padding: 4px;
+}
+
+.tabBtn {
+  padding: 10px 24px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.tabBtn:hover {
+  color: var(--color-text);
+}
+
+.tabBtnActive {
+  background: var(--color-primary);
+  color: white;
+}
+
+.tabBtnActive:hover {
+  color: white;
+}
+
+.tabHint {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+/* Grid with fade-in animation */
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .card {
@@ -138,5 +195,9 @@
   }
   .section {
     padding: 60px 20px;
+  }
+  .tabBtn {
+    padding: 8px 16px;
+    font-size: 14px;
   }
 }

--- a/src/components/Skills/Skills.tsx
+++ b/src/components/Skills/Skills.tsx
@@ -1,51 +1,93 @@
+import { useState } from 'react'
 import styles from './Skills.module.css'
 
-const skills = [
+const personalSkills = [
   {
     icon: '🔍',
-    title: '智能搜索与问答',
-    desc: '"我记得之前写过一篇关于 xxx 的文档" → 秒找到并总结关键内容。',
-    tags: ['search_docs', 'get_doc_content', 'ai_summarize'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/smart-search',
+    title: '个人智能搜索',
+    desc: '搜索个人知识库文档，自然语言提问，秒找到并总结关键内容。',
+    tags: ['search_docs', 'get_doc_content'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/personal-search',
   },
   {
     icon: '📝',
-    title: '会议纪要归档',
-    desc: '开完会丢给 AI，自动整理格式并归档到知识库对应目录。',
-    tags: ['create_doc', 'update_doc', 'move_to_repo'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/meeting-notes',
+    title: '个人会议纪要',
+    desc: '开完会丢给 AI，自动整理格式并归档到个人知识库。',
+    tags: ['create_doc', 'update_doc', 'list_repos'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/personal-meeting-notes',
   },
   {
     icon: '📊',
-    title: '周报生成',
-    desc: '汇总本周文档动态，一键生成结构化周报草稿。',
-    tags: ['list_recent_docs', 'get_doc_content', 'create_doc'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/weekly-report',
+    title: '个人周报',
+    desc: '汇总本周个人文档创建和更新动态，一键生成周报。',
+    tags: ['list_docs', 'get_doc_content', 'create_doc'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/personal-weekly',
   },
   {
     icon: '📐',
-    title: '技术方案撰写',
-    desc: '给个需求描述，按团队模板自动生成方案骨架，省去重复排版。',
-    tags: ['get_template', 'create_doc', 'update_doc'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/tech-design',
+    title: '个人技术方案',
+    desc: '给个需求描述，自动生成技术方案骨架，存到个人知识库。',
+    tags: ['create_doc', 'update_doc'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/personal-tech-design',
+  },
+]
+
+const teamSkills = [
+  {
+    icon: '🔍',
+    title: '团队智能搜索',
+    desc: '搜索团队知识库，快速定位团队沉淀的文档和知识。',
+    tags: ['search_docs', 'get_doc_content', 'list_group_repos'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-search',
+  },
+  {
+    icon: '📝',
+    title: '团队会议纪要',
+    desc: '会议纪要自动归档到团队知识库，全员可查。',
+    tags: ['create_doc', 'update_doc', 'list_group_repos'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-meeting-notes',
+  },
+  {
+    icon: '📊',
+    title: '团队周报',
+    desc: '汇总团队成员文档贡献，自动生成团队周报。',
+    tags: ['group_doc_stats', 'group_member_stats', 'create_doc'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-weekly',
+  },
+  {
+    icon: '📐',
+    title: '团队技术方案',
+    desc: '按团队模板生成技术方案，存到团队知识库待评审。',
+    tags: ['create_doc', 'update_doc', 'list_group_repos'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-tech-design',
   },
   {
     icon: '🎒',
-    title: '新人入职知识包',
+    title: '新人入职指南',
     desc: '自动整理团队核心文档，生成入职阅读指南和学习路径。',
-    tags: ['list_repo_docs', 'get_doc_content', 'create_doc'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/onboarding-guide',
+    tags: ['list_group_repos', 'list_docs', 'create_doc'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-onboarding',
   },
   {
     icon: '📈',
     title: '团队知识月报',
     desc: '月底自动统计文档产出和知识沉淀趋势，量化团队知识资产。',
-    tags: ['list_group_repos', 'list_recent_docs', 'create_doc'],
-    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/knowledge-report',
+    tags: ['group_stats', 'group_member_stats', 'create_doc'],
+    link: 'https://github.com/yuque/yuque-skills/tree/main/skills/team-knowledge-report',
   },
 ]
 
+type Scenario = 'personal' | 'team'
+
+const scenarioHint: Record<Scenario, string> = {
+  personal: '使用个人 Token，管理个人知识库',
+  team: '使用团队 Token（旗舰版），管理团队知识库',
+}
+
 function Skills() {
+  const [active, setActive] = useState<Scenario>('personal')
+  const skills = active === 'personal' ? personalSkills : teamSkills
+
   return (
     <section className={styles.section}>
       <p className={styles.sectionLabel}>Skills</p>
@@ -63,7 +105,26 @@ function Skills() {
       <p className={styles.sectionDesc}>
         每个 Skill 都是一个精心编排的工作流，将多个 Tools 组合成开箱即用的解决方案。
       </p>
-      <div className={styles.grid}>
+
+      <div className={styles.tabWrapper}>
+        <div className={styles.tabContainer}>
+          <button
+            className={`${styles.tabBtn} ${active === 'personal' ? styles.tabBtnActive : ''}`}
+            onClick={() => setActive('personal')}
+          >
+            👤 个人场景
+          </button>
+          <button
+            className={`${styles.tabBtn} ${active === 'team' ? styles.tabBtnActive : ''}`}
+            onClick={() => setActive('team')}
+          >
+            👥 团队场景
+          </button>
+        </div>
+        <p className={styles.tabHint}>{scenarioHint[active]}</p>
+      </div>
+
+      <div className={styles.grid} key={active}>
         {skills.map((s) => (
           <div key={s.title} className={styles.card}>
             <span className={styles.cardIcon}>{s.icon}</span>


### PR DESCRIPTION
## 改动说明

改造 Skills 组件，添加「个人 / 团队」场景切换功能。

### 变更内容

- 将 skills 数据拆分为 personalSkills（4 个）和 teamSkills（6 个）两组
- 在 sectionDesc 和 grid 之间添加 segment-control 风格的 tab 切换栏
- 两个按钮：👤 个人场景 / 👥 团队场景
- 选中态使用 `var(--color-primary)` 背景 + 白色文字
- tab 下方显示场景说明文字（个人 Token / 团队 Token）
- 切换时卡片区域有 fadeIn 动画过渡
- 移动端适配：小屏幕下 tab 按钮缩小
- 默认选中「个人场景」

### 参考设计

语雀定价页 https://www.yuque.com/about/price 的个人版/团队版切换效果