### PR TITLE
fix: correct install/upgrade commands to use valid CLI syntax

### DIFF
--- a/src/components/Upgrade/Upgrade.tsx
+++ b/src/components/Upgrade/Upgrade.tsx
@@ -17,10 +17,10 @@ function Upgrade() {
               当我们发布新版本的 Skills 时，你可以通过以下方式更新：
             </p>
             <div className={styles.codeBlock}>
-              <span className={styles.codeComment}># 更新 Marketplace 目录</span>{'\n'}
-              /plugin marketplace update{'\n'}{'\n'}
-              <span className={styles.codeComment}># 重新安装 Plugin 以获取最新版本</span>{'\n'}
-              /plugin install yuque@yuque-ecosystem
+              <span className={styles.codeComment}># 在终端中更新</span>{'\n'}
+              claude plugin update yuque@yuque-ecosystem{'\n'}{'\n'}
+              <span className={styles.codeComment}># 或在 Claude Code 内部</span>{'\n'}
+              /plugin marketplace update yuque-ecosystem
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 问题

官网中的安装命令使用了不存在的 CLI 子命令：
- `claude plugin add github:yuque/yuque-plugin` — 没有 `add` 子命令
- `claude plugin search yuque` — 没有 `search` 子命令
- `claude plugin add yuque-plugin` — 没有 `add` 子命令

## 修正

**Plugin.tsx（安装区域）：**
- 方式一（终端）：`claude plugin marketplace add` + `claude plugin install`
- 方式二（Claude Code 内部）：`/plugin marketplace add` + `/plugin install`

**Upgrade.tsx（更新区域）：**
- 终端：`claude plugin update yuque@yuque-ecosystem`
- Claude Code 内部：`/plugin marketplace update yuque-ecosystem`