### PR TITLE
fix: update marketplace.json — version 1.1.0 + correct description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "yuque-ecosystem",
-  "version": "1.0.0",
-  "description": "语雀 AI 生态 Plugin Marketplace — MCP Tools, Skills, and Agents for Yuque",
+  "version": "1.1.0",
+  "description": "语雀 AI 生态 Plugin Marketplace — MCP Tools and Skills for Yuque",
   "owner": {
     "name": "yuque",
     "email": "willchen.babydog@gmail.com"
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "yuque",
-      "description": "语雀知识库 AI 集成 — 25 MCP Tools + 6 Skills + 专业 Agent",
-      "version": "1.0.0",
+      "description": "语雀知识库 AI 集成 — 25 MCP Tools + 10 Skills",
+      "version": "1.1.0",
       "author": {
         "name": "yuque"
       },


### PR DESCRIPTION
marketplace.json 版本和描述没有同步更新：
- version: 1.0.0 → 1.1.0
- description: 去掉 Agent，Skills 6 → 10
- marketplace version 也同步到 1.1.0

不更新的话用户 marketplace update 后重装还是拿到旧版本。