### PR TITLE
fix: correct install commands and improve page layout structure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,10 @@ function App() {
     <>
       <Hero />
       <Modules />
-      <DesignPhilosophy />
       <McpTools />
-      <Skills />
       <GroupPreview />
+      <DesignPhilosophy />
+      <Skills />
       <div id="quick-start">
         <QuickStart />
       </div>

--- a/src/components/DesignPhilosophy/DesignPhilosophy.tsx
+++ b/src/components/DesignPhilosophy/DesignPhilosophy.tsx
@@ -38,7 +38,7 @@ const phases = [
 function DesignPhilosophy() {
   return (
     <section className={styles.section}>
-      <p className={styles.sectionLabel}>Design Philosophy</p>
+      <p className={styles.sectionLabel}>Design Philosophy · 个人版</p>
       <h2 className={styles.sectionTitle}>语雀 = 你的第二大脑</h2>
       <p className={styles.sectionDesc}>
         知识不该只是存着。从输入到输出，AI Skills 覆盖知识管理的完整生命周期，

--- a/src/components/QuickStart/QuickStart.tsx
+++ b/src/components/QuickStart/QuickStart.tsx
@@ -8,7 +8,7 @@ function QuickStart() {
 
   return (
     <section className={styles.section}>
-      <p className={styles.sectionLabel}>Quick Start</p>
+      <p className={styles.sectionLabel}>Quick Start · 个人版</p>
       <div className={styles.titleRow}>
         <h2 className={styles.sectionTitle}>开始使用</h2>
         <a
@@ -21,7 +21,7 @@ function QuickStart() {
         </a>
       </div>
       <p className={styles.sectionDesc}>
-        两种方式接入语雀 AI 能力，推荐使用 Plugin 一键安装。
+        两种方式接入语雀个人版 AI 能力，推荐使用 Plugin 一键安装。团队版即将推出，敬请期待。
       </p>
 
       <div className={styles.tabWrapper}>
@@ -48,7 +48,7 @@ function QuickStart() {
             <div className={styles.stepContent}>
               <h3 className={styles.stepTitle}>添加语雀 Marketplace</h3>
               <div className={styles.codeBlock}>
-                claude plugin marketplace add yuque/yuque-plugin
+                /plugin marketplace add yuque/yuque-plugin
               </div>
             </div>
           </div>
@@ -58,12 +58,12 @@ function QuickStart() {
           <div className={styles.step}>
             <div className={styles.stepNumber}>2</div>
             <div className={styles.stepContent}>
-              <h3 className={styles.stepTitle}>安装 Plugin</h3>
+              <h3 className={styles.stepTitle}>安装个人版 Plugin</h3>
               <p className={styles.stepDesc}>
                 自动配置 MCP Server + Skills，开箱即用。
               </p>
               <div className={styles.codeBlock}>
-                claude plugin install yuque@yuque
+                /plugin install yuque-personal@yuque
               </div>
             </div>
           </div>

--- a/src/components/Skills/Skills.tsx
+++ b/src/components/Skills/Skills.tsx
@@ -77,7 +77,7 @@ const personalSkills = [
 function Skills() {
   return (
     <section className={styles.section}>
-      <p className={styles.sectionLabel}>Skills</p>
+      <p className={styles.sectionLabel}>Skills · 个人版</p>
       <div className={styles.titleRow}>
         <h2 className={styles.sectionTitle}>场景化 AI 工作流</h2>
         <a

--- a/src/components/Upgrade/Upgrade.tsx
+++ b/src/components/Upgrade/Upgrade.tsx
@@ -18,9 +18,9 @@ function Upgrade() {
             </p>
             <div className={styles.codeBlock}>
               <span className={styles.codeComment}># 在终端中更新</span>{'\n'}
-              claude plugin update yuque@yuque{'\n'}{'\n'}
+              claude plugin update yuque-personal@yuque{'\n'}{'\n'}
               <span className={styles.codeComment}># 或在 Claude Code 内部</span>{'\n'}
-              /plugin update yuque@yuque
+              /plugin update yuque-personal@yuque
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Changes

### 1. Fix install commands
对照 `yuque-plugin` 仓库的实际配置，修正官网中的安装命令：

- marketplace add: `/plugin marketplace add yuque/yuque-plugin`
- plugin install: `/plugin install yuque-personal@yuque`（之前错误写成 `yuque@yuque`）
- plugin update: `yuque-personal@yuque`

### 2. Improve page layout structure
调整页面组件顺序，建立清晰的逻辑层次：

1. **Hero** — 整体介绍语雀 AI 生态
2. **Modules** — 三层架构介绍
3. **MCP Tools** — 25 个工具（个人+团队通用基础能力）
4. **Editions** — 个人版 vs 团队版场景介绍
5. **Design Philosophy（个人版）** — 第二大脑设计理念
6. **Skills（个人版）** — 场景化 AI 工作流
7. **Quick Start（个人版）** — 安装指南（团队版 Coming Soon）
8. **Upgrade** — 更新指南

关键改动：
- 将 GroupPreview（Editions）提前到个人版详情之前，让用户先了解两个方向
- 为 DesignPhilosophy、Skills、QuickStart 添加「个人版」标识
- QuickStart 描述中注明团队版即将推出