### PR TITLE
fix: improve Plugin install flow and add environment labels

### DIFF
--- a/src/components/PluginInstall/PluginInstall.module.css
+++ b/src/components/PluginInstall/PluginInstall.module.css
@@ -123,6 +123,29 @@
   text-decoration: underline;
 }
 
+.envTag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  margin-left: 8px;
+}
+
+.envTerminal {
+  background: rgba(99, 179, 237, 0.12);
+  color: #63b3ed;
+}
+
+.envClaude {
+  background: rgba(214, 138, 68, 0.12);
+  color: #d68a44;
+}
+
 .codeComment {
   color: var(--color-text-muted);
 }

--- a/src/components/PluginInstall/PluginInstall.tsx
+++ b/src/components/PluginInstall/PluginInstall.tsx
@@ -23,9 +23,12 @@ function PluginInstall() {
 
       <div className={styles.steps}>
         <div className={styles.step}>
-          <div className={styles.stepNumber}>0</div>
+          <div className={styles.stepNumber}>1</div>
           <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>前置准备：安装 Claude Code</h3>
+            <h3 className={styles.stepTitle}>
+              安装 Claude Code
+              <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
+            </h3>
             <p className={styles.stepDesc}>
               语雀 Plugin 基于{' '}
               <a
@@ -36,7 +39,7 @@ function PluginInstall() {
               >
                 Claude Code
               </a>
-              {' '}运行，请先完成安装并确保可以正常启动。
+              {' '}运行，请先完成安装。
             </p>
             <CodeBlock>
               npm install -g @anthropic-ai/claude-code
@@ -47,36 +50,12 @@ function PluginInstall() {
         <div className={styles.divider} />
 
         <div className={styles.step}>
-          <div className={styles.stepNumber}>1</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>添加语雀 Marketplace</h3>
-            <CodeBlock>
-              /plugin marketplace add yuque/yuque-plugin
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className={styles.divider} />
-
-        <div className={styles.step}>
           <div className={styles.stepNumber}>2</div>
           <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>安装个人版 Plugin</h3>
-            <p className={styles.stepDesc}>
-              自动配置 MCP Server + Skills，开箱即用。
-            </p>
-            <CodeBlock>
-              /plugin install yuque-personal@yuque
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className={styles.divider} />
-
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>3</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>设置语雀 Token（永久生效）</h3>
+            <h3 className={styles.stepTitle}>
+              设置语雀 Token
+              <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
+            </h3>
             <p className={styles.stepDesc}>
               前往{' '}
               <a
@@ -87,11 +66,47 @@ function PluginInstall() {
               >
                 语雀 Token 设置页
               </a>
-              {' '}获取 Token，然后写入 shell 配置文件：
+              {' '}获取 Token，写入 shell 配置后进入 Claude Code：
             </p>
             <CodeBlock>
               <span className={styles.codeComment}># 写入 ~/.zshrc，新终端自动生效</span>{'\n'}
               echo 'export YUQUE_PERSONAL_TOKEN=<span className={styles.codeHighlight}>"your-token-here"</span>' {'>>'}  ~/.zshrc && source ~/.zshrc
+            </CodeBlock>
+          </div>
+        </div>
+
+        <div className={styles.divider} />
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>3</div>
+          <div className={styles.stepContent}>
+            <h3 className={styles.stepTitle}>
+              添加语雀 Marketplace
+              <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
+            </h3>
+            <p className={styles.stepDesc}>
+              启动 Claude Code 后，输入以下命令：
+            </p>
+            <CodeBlock>
+              /plugin marketplace add yuque/yuque-plugin
+            </CodeBlock>
+          </div>
+        </div>
+
+        <div className={styles.divider} />
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>4</div>
+          <div className={styles.stepContent}>
+            <h3 className={styles.stepTitle}>
+              安装个人版 Plugin
+              <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
+            </h3>
+            <p className={styles.stepDesc}>
+              自动配置 MCP Server + Skills，开箱即用。
+            </p>
+            <CodeBlock>
+              /plugin install yuque-personal@yuque
             </CodeBlock>
           </div>
         </div>


### PR DESCRIPTION
## Problem

当前 Plugin 安装教程有两个体验问题：

1. **步骤顺序反人性** — Token 设置放在最后（Step 3），但前面 Step 1-2 用户已经进入 Claude Code 了，还得退出去设环境变量
2. **没标注执行环境** — 用户不知道哪些命令在终端跑、哪些在 Claude Code 里输入

## Solution

### 步骤重排
| Before | After |
|---|---|
| 0. 安装 Claude Code (终端) | 1. 安装 Claude Code (终端) |
| 1. 添加 Marketplace (Claude Code) | **2. 设置语雀 Token (终端)** |
| 2. 安装 Plugin (Claude Code) | 3. 添加 Marketplace (Claude Code) |
| 3. 设置 Token (终端 ← 要退出!) | 4. 安装 Plugin (Claude Code) |

终端操作集中在前半段，Claude Code 操作在后半段，用户不需要来回切换。

### 环境标签
每个步骤标题后加了彩色标签：
- `🖥️ 终端` — 蓝色，表示在系统终端执行
- `🤖 Claude Code` — 橙色，表示在 Claude Code 内输入

## Files changed (2)
- `PluginInstall.module.css` — 环境标签样式（.envTag / .envTerminal / .envClaude）
- `PluginInstall.tsx` — 步骤重排 + 环境标签 JSX