### PR TITLE
feat: add Qoder tab to McpQuickStart component

### DIFF
--- a/src/components/McpQuickStart/McpQuickStart.tsx
+++ b/src/components/McpQuickStart/McpQuickStart.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import styles from './McpQuickStart.module.css'
 import CodeBlock from '../CodeBlock/CodeBlock'
 
-type Client = 'cursor' | 'vscode' | 'windsurf' | 'claude-desktop' | 'trae' | 'cline'
+type Client = 'cursor' | 'vscode' | 'windsurf' | 'claude-desktop' | 'trae' | 'qoder' | 'cline'
 
 interface ClientInfo {
   id: Client
@@ -16,6 +16,7 @@ const clients: ClientInfo[] = [
   { id: 'windsurf', label: 'Windsurf', flag: 'windsurf' },
   { id: 'claude-desktop', label: 'Claude Desktop', flag: 'claude-desktop' },
   { id: 'trae', label: 'Trae', flag: 'trae' },
+  { id: 'qoder', label: 'Qoder', flag: 'qoder' },
   { id: 'cline', label: 'Cline', flag: 'cline' },
 ]
 


### PR DESCRIPTION
Add Qoder (Alibaba's AI IDE, formerly Tongyi Lingma) as the 7th MCP client tab in the McpQuickStart component.

- Added `qoder` to the Client type and clients array
- Positioned between Trae and Cline
- Qoder uses the same JSON config format as Cursor

Qoder MCP configuration:
1. Open Qoder IDE
2. Open Qoder Settings via user icon or ⌘⇧, / Ctrl+Shift+,
3. Navigate to MCP → click + Add
4. Paste the JSON configuration
5. Save and verify the connection icon appears