### PR TITLE
feat: update website content for ecosystem consolidation

### DIFF
--- a/website/src/components/Footer/Footer.tsx
+++ b/website/src/components/Footer/Footer.tsx
@@ -48,6 +48,14 @@ function Footer() {
         >
           npm
         </a>
+        <a
+          href="https://www.yuque.com/yuque/ai/yuque-ai-ecosystem-final"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+        >
+          Blog
+        </a>
         <span className={styles.link}>MIT License</span>
       </div>
       {(pvCount || uvCount) && (

--- a/website/src/components/Modules/Modules.tsx
+++ b/website/src/components/Modules/Modules.tsx
@@ -16,8 +16,8 @@ const modules = [
   {
     icon: '🧩',
     title: 'Plugin',
-    desc: '一键集成 MCP + Skills，让 Claude Code 开箱即用地操作语雀，零配置上手。',
-    meta: '25 Tools + 8 Skills',
+    desc: '一键集成 MCP + Skills，让 AI 助手开箱即用地操作语雀。支持 Claude Code、OpenClaw 等客户端。',
+    meta: '25 Tools + 14 Skills',
   },
 ]
 

--- a/website/src/components/PluginInstall/PluginInstall.tsx
+++ b/website/src/components/PluginInstall/PluginInstall.tsx
@@ -1,15 +1,18 @@
+import { useState } from 'react'
 import styles from './PluginInstall.module.css'
 import CodeBlock from '../CodeBlock/CodeBlock'
 
 function PluginInstall() {
+  const [activeTab, setActiveTab] = useState<'claude-code' | 'openclaw'>('claude-code')
+
   return (
     <section className={styles.section}>
       <p className={styles.sectionLabel}>Advanced</p>
       <div className={styles.titleRow}>
-        <h2 className={styles.sectionTitle}>⚡ Claude Code Plugin</h2>
+        <h2 className={styles.sectionTitle}>⚡ Plugin 安装</h2>
         <a
           className={styles.externalLink}
-          href="https://github.com/yuque/yuque-plugin"
+          href="https://github.com/yuque/yuque-ecosystem"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -17,100 +20,188 @@ function PluginInstall() {
         </a>
       </div>
       <p className={styles.sectionDesc}>
-        Plugin = MCP Server + 8 个智能 Skills，适合 Claude Code 高级用户。
-        <span className={styles.advancedBadge}>高级</span>
+        Plugin = MCP Server + Skills，选择你的 AI 客户端，一键安装。
       </p>
 
-      <div className={styles.steps}>
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>1</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>
-              安装 Claude Code
-              <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
-            </h3>
-            <p className={styles.stepDesc}>
-              语雀 Plugin 基于{' '}
-              <a
-                href="https://docs.anthropic.com/en/docs/claude-code"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.link}
-              >
-                Claude Code
-              </a>
-              {' '}运行，请先完成安装。
-            </p>
-            <CodeBlock>
-              npm install -g @anthropic-ai/claude-code
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className={styles.divider} />
-
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>2</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>
-              设置语雀 Token
-              <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
-            </h3>
-            <p className={styles.stepDesc}>
-              前往{' '}
-              <a
-                href="https://www.yuque.com/settings/tokens"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.link}
-              >
-                语雀 Token 设置页
-              </a>
-              {' '}获取 Token，写入 shell 配置后进入 Claude Code：
-            </p>
-            <CodeBlock>
-              <span className={styles.codeComment}># 写入 ~/.zshrc，新终端自动生效</span>{'\n'}
-              echo 'export YUQUE_PERSONAL_TOKEN=<span className={styles.codeHighlight}>"your-token-here"</span>' {'>>'}  ~/.zshrc && source ~/.zshrc
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className={styles.divider} />
-
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>3</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>
-              添加语雀 Marketplace
-              <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
-            </h3>
-            <p className={styles.stepDesc}>
-              启动 Claude Code 后，输入以下命令：
-            </p>
-            <CodeBlock>
-              /plugin marketplace add yuque/yuque-plugin
-            </CodeBlock>
-          </div>
-        </div>
-
-        <div className={styles.divider} />
-
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>4</div>
-          <div className={styles.stepContent}>
-            <h3 className={styles.stepTitle}>
-              安装个人版 Plugin
-              <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
-            </h3>
-            <p className={styles.stepDesc}>
-              自动配置 MCP Server + Skills，开箱即用。
-            </p>
-            <CodeBlock>
-              /plugin install yuque-personal@yuque
-            </CodeBlock>
-          </div>
-        </div>
+      <div style={{
+        display: 'flex',
+        justifyContent: 'center',
+        gap: '8px',
+        marginBottom: '36px',
+      }}>
+        <button
+          style={{
+            padding: '10px 20px',
+            borderRadius: '10px',
+            border: activeTab === 'claude-code' ? '1px solid rgba(0, 185, 107, 0.4)' : '1px solid var(--color-border)',
+            background: activeTab === 'claude-code' ? 'rgba(0, 185, 107, 0.08)' : 'transparent',
+            color: activeTab === 'claude-code' ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontWeight: 600,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            transition: 'all 0.2s ease',
+          }}
+          onClick={() => setActiveTab('claude-code')}
+        >
+          🤖 Claude Code
+          <span style={{
+            padding: '2px 8px',
+            borderRadius: '100px',
+            fontSize: '11px',
+            fontWeight: 700,
+            background: 'rgba(0, 185, 107, 0.12)',
+            color: '#00b96b',
+          }}>推荐</span>
+        </button>
+        <button
+          style={{
+            padding: '10px 20px',
+            borderRadius: '10px',
+            border: activeTab === 'openclaw' ? '1px solid rgba(0, 185, 107, 0.4)' : '1px solid var(--color-border)',
+            background: activeTab === 'openclaw' ? 'rgba(0, 185, 107, 0.08)' : 'transparent',
+            color: activeTab === 'openclaw' ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontWeight: 600,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            transition: 'all 0.2s ease',
+          }}
+          onClick={() => setActiveTab('openclaw')}
+        >
+          🐾 OpenClaw
+          <span style={{
+            padding: '2px 8px',
+            borderRadius: '100px',
+            fontSize: '11px',
+            fontWeight: 700,
+            background: 'rgba(255, 196, 0, 0.12)',
+            color: '#ffc400',
+          }}>Coming Soon</span>
+        </button>
       </div>
+
+      {activeTab === 'claude-code' ? (
+        <div className={styles.steps}>
+          <div className={styles.step}>
+            <div className={styles.stepNumber}>1</div>
+            <div className={styles.stepContent}>
+              <h3 className={styles.stepTitle}>
+                安装 Claude Code
+                <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
+              </h3>
+              <p className={styles.stepDesc}>
+                Claude Code Plugin 基于{' '}
+                <a
+                  href="https://docs.anthropic.com/en/docs/claude-code"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.link}
+                >
+                  Claude Code
+                </a>
+                {' '}运行，适合开发者使用。请先完成安装。
+              </p>
+              <CodeBlock>
+                npm install -g @anthropic-ai/claude-code
+              </CodeBlock>
+            </div>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.step}>
+            <div className={styles.stepNumber}>2</div>
+            <div className={styles.stepContent}>
+              <h3 className={styles.stepTitle}>
+                设置语雀 Token
+                <span className={`${styles.envTag} ${styles.envTerminal}`}>🖥️ 终端</span>
+              </h3>
+              <p className={styles.stepDesc}>
+                前往{' '}
+                <a
+                  href="https://www.yuque.com/settings/tokens"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.link}
+                >
+                  语雀 Token 设置页
+                </a>
+                {' '}获取 Token，写入 shell 配置后进入 Claude Code：
+              </p>
+              <CodeBlock>
+                <span className={styles.codeComment}># 写入 ~/.zshrc，新终端自动生效</span>{'\n'}
+                echo 'export YUQUE_PERSONAL_TOKEN=<span className={styles.codeHighlight}>"your-token-here"</span>' {'>>'}  ~/.zshrc && source ~/.zshrc
+              </CodeBlock>
+            </div>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.step}>
+            <div className={styles.stepNumber}>3</div>
+            <div className={styles.stepContent}>
+              <h3 className={styles.stepTitle}>
+                添加语雀 Marketplace
+                <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
+              </h3>
+              <p className={styles.stepDesc}>
+                启动 Claude Code 后，输入以下命令：
+              </p>
+              <CodeBlock>
+                /plugin marketplace add yuque/yuque-ecosystem
+              </CodeBlock>
+            </div>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.step}>
+            <div className={styles.stepNumber}>4</div>
+            <div className={styles.stepContent}>
+              <h3 className={styles.stepTitle}>
+                安装个人版 Plugin
+                <span className={`${styles.envTag} ${styles.envClaude}`}>🤖 Claude Code</span>
+              </h3>
+              <p className={styles.stepDesc}>
+                自动配置 MCP Server + Skills，开箱即用。
+              </p>
+              <CodeBlock>
+                /plugin install yuque-personal@yuque
+              </CodeBlock>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.steps}>
+          <div className={styles.step}>
+            <div className={styles.stepContent} style={{ textAlign: 'center', padding: '48px 0' }}>
+              <p style={{ fontSize: '48px', marginBottom: '16px' }}>🐾</p>
+              <h3 className={styles.stepTitle} style={{ textAlign: 'center', marginBottom: '12px' }}>
+                OpenClaw Plugin · Coming Soon
+              </h3>
+              <p className={styles.stepDesc} style={{ textAlign: 'center', maxWidth: '480px', margin: '0 auto' }}>
+                OpenClaw Plugin 适合所有用户，基于 OpenClaw Agent 运行，无需开发者环境。
+                <br />
+                正在开发中，敬请期待！
+              </p>
+              <a
+                href="https://github.com/yuque/yuque-ecosystem"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.link}
+                style={{ fontSize: '14px' }}
+              >
+                关注 GitHub 获取最新动态 →
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/website/src/components/Skills/Skills.tsx
+++ b/website/src/components/Skills/Skills.tsx
@@ -8,7 +8,7 @@ const personalSkills = [
     desc: '阅读文章后自动提取核心观点、金句、行动项，生成结构化阅读笔记。',
     tags: ['get_doc', 'create_doc', 'search'],
     category: '📥 输入',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-reading-digest',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/reading-digest',
   },
   {
     icon: '💡',
@@ -16,7 +16,7 @@ const personalSkills = [
     desc: '随时记录灵感和想法，定期自动归类整理，合并成结构化的主题笔记。',
     tags: ['search', 'create_doc', 'update_doc'],
     category: '📥 输入',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-daily-capture',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/daily-capture',
   },
   // 🧠 加工
   {
@@ -25,7 +25,7 @@ const personalSkills = [
     desc: '把粗糙笔记打磨成高质量文档，补充结构、优化表达、改善排版。',
     tags: ['get_doc', 'update_doc'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-note-refine',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/note-refine',
   },
   {
     icon: '🕸️',
@@ -33,7 +33,7 @@ const personalSkills = [
     desc: '分析知识库文档间的隐藏联系，建议交叉引用链接，构建知识网络。',
     tags: ['get_repo_docs', 'get_doc', 'update_doc', 'search'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-knowledge-connect',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/knowledge-connect',
   },
   {
     icon: '✍️',
@@ -41,7 +41,7 @@ const personalSkills = [
     desc: '分析你的写作风格，生成风格画像，帮你保持一致的文风写新内容。',
     tags: ['get_repo_docs', 'get_doc', 'create_doc'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-style-extract',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/style-extract',
   },
   // 📤 输出
   {
@@ -50,7 +50,7 @@ const personalSkills = [
     desc: '自然语言搜索个人知识库，秒找到并总结关键内容。',
     tags: ['search', 'get_doc'],
     category: '📤 输出',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-smart-search',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/smart-search',
   },
   {
     icon: '📋',
@@ -58,7 +58,7 @@ const personalSkills = [
     desc: '对任意文档或知识库生成不同粒度的摘要：一句话、要点、详细。',
     tags: ['get_doc', 'get_repo_docs'],
     category: '📤 输出',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-smart-summary',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/smart-summary',
   },
   // 🔄 维护
   {
@@ -67,7 +67,7 @@ const personalSkills = [
     desc: '扫描知识库发现过期文档，生成健康报告，建议更新或归档。',
     tags: ['get_repo_docs', 'get_doc', 'search'],
     category: '🔄 维护',
-    link: 'https://github.com/yuque/yuque-plugin/tree/main/plugins/yuque-personal/skills/yuque-personal-stale-detector',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/stale-detector',
   },
 ]
 
@@ -82,7 +82,7 @@ function Skills() {
         <h2 className={styles.sectionTitle}>场景化 AI 工作流</h2>
         <a
           className={styles.externalLink}
-          href="https://github.com/yuque/yuque-plugin"
+          href="https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/website/src/components/Upgrade/Upgrade.tsx
+++ b/website/src/components/Upgrade/Upgrade.tsx
@@ -15,13 +15,20 @@ function Upgrade() {
           <div className={styles.stepContent}>
             <h3 className={styles.stepTitle}>更新 Plugin（Skills）</h3>
             <p className={styles.stepDesc}>
-              当我们发布新版本的 Skills 时，你可以通过以下方式更新：
+              仓库已迁移到{' '}
+              <a href="https://github.com/yuque/yuque-ecosystem" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--color-primary)' }}>
+                yuque-ecosystem
+              </a>
+              ，当我们发布新版本的 Skills 时，你可以通过以下方式更新：
             </p>
             <CodeBlock>
               <span className={styles.codeComment}># 在终端中更新</span>{'\n'}
               claude plugin update yuque-personal@yuque{'\n'}{'\n'}
               <span className={styles.codeComment}># 或在 Claude Code 内部</span>{'\n'}
-              /plugin update yuque-personal@yuque
+              /plugin update yuque-personal@yuque{'\n'}{'\n'}
+              <span className={styles.codeComment}># ⚠️ 从旧的 yuque-plugin 迁移？先移除旧 marketplace：</span>{'\n'}
+              /plugin marketplace remove yuque/yuque-plugin{'\n'}
+              /plugin marketplace add yuque/yuque-ecosystem
             </CodeBlock>
           </div>
         </div>


### PR DESCRIPTION
## Changes

Updates the website content to reflect the monorepo migration from `yuque-plugin` to `yuque-ecosystem`.

### PluginInstall.tsx — Major redesign
- Redesigned as a tabbed interface with **Claude Code Plugin** (active) and **OpenClaw Plugin** (Coming Soon)
- Updated GitHub link: `yuque/yuque-plugin` → `yuque/yuque-ecosystem`
- Updated marketplace add command: `yuque/yuque-plugin` → `yuque/yuque-ecosystem`
- OpenClaw tab shows Coming Soon placeholder with link to GitHub

### Skills.tsx — Updated links
- All 8 skill links updated from `yuque-plugin/plugins/yuque-personal/skills/yuque-personal-*` to `yuque-ecosystem/plugins/claude-code/personal/skills/*`
- "View on GitHub →" link updated to point to `yuque-ecosystem/tree/main/plugins/claude-code`

### Upgrade.tsx — Migration guidance
- Added note about repository migration to yuque-ecosystem
- Added migration commands for users coming from old yuque-plugin marketplace

### Modules.tsx — Copy updates
- Plugin description updated to mention multi-client support (Claude Code, OpenClaw)
- Skills count updated from "25 Tools + 8 Skills" to "25 Tools + 14 Skills" (8 personal + 6 team)

### Footer.tsx — Blog link
- Added Blog link pointing to `yuque-ai-ecosystem-final` article

### Verification
- `npm run build` passes successfully
- No CSS files modified — only TSX content changes