### PR TITLE
fix: correct VS Code MCP description to clarify GitHub Copilot requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [`plugins/opencode/`](./plugins/opencode/) for skills installation and full 
 
 ### Other Editors
 
-See [`shared/mcp-config/`](./shared/mcp-config/) for configuration templates for Cursor, Windsurf, VS Code, and more.
+See [`shared/mcp-config/`](./shared/mcp-config/) for configuration templates for Cursor, Windsurf, GitHub Copilot (VS Code), and more.
 
 ## Modules
 

--- a/shared/mcp-config/README.md
+++ b/shared/mcp-config/README.md
@@ -10,8 +10,10 @@ Copy the appropriate config file and replace `YOUR_YUQUE_TOKEN` with your actual
 |--------|-------------|-------------|
 | Cursor | `cursor.json` | `.cursor/mcp.json` |
 | Windsurf | `windsurf.json` | `.windsurf/mcp.json` |
-| VS Code (Copilot) | `vscode.json` | `.vscode/mcp.json` |
+| GitHub Copilot (VS Code) | `vscode.json` | `.vscode/mcp.json` |
 | OpenCode | `opencode.json` | `opencode.json` (project) or `~/.config/opencode/opencode.json` (global) |
+
+> **Note:** VS Code itself does not support MCP natively; MCP support is provided through the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) extension. Make sure GitHub Copilot is installed in VS Code before using the `vscode.json` configuration.
 
 ## Claude Code
 

--- a/website/src/components/McpQuickStart/McpQuickStart.tsx
+++ b/website/src/components/McpQuickStart/McpQuickStart.tsx
@@ -11,8 +11,8 @@ interface ClientInfo {
 }
 
 const clients: ClientInfo[] = [
-  { id: 'vscode', label: 'VS Code', flag: 'vscode' },
   { id: 'cursor', label: 'Cursor', flag: 'cursor' },
+  { id: 'vscode', label: 'GitHub Copilot', flag: 'vscode' },
   { id: 'windsurf', label: 'Windsurf', flag: 'windsurf' },
   { id: 'claude-desktop', label: 'Claude Desktop', flag: 'claude-desktop' },
   { id: 'trae', label: 'Trae', flag: 'trae' },
@@ -21,7 +21,7 @@ const clients: ClientInfo[] = [
 ]
 
 function McpQuickStart() {
-  const [activeClient, setActiveClient] = useState<Client>('vscode')
+  const [activeClient, setActiveClient] = useState<Client>('cursor')
 
   const currentClient = clients.find((c) => c.id === activeClient)!
 


### PR DESCRIPTION
## Summary

VS Code itself does not support MCP natively — MCP support is provided through the GitHub Copilot extension. This PR corrects all user-facing references to clarify this.

## Changes

### Website (`McpQuickStart.tsx`)
- Renamed `VS Code` label → `GitHub Copilot` in the client tab selector
- Changed default active client from `vscode` → `cursor` (Cursor has native MCP support, more appropriate as default)
- Reordered tabs: Cursor now appears first

### `shared/mcp-config/README.md`
- `VS Code (Copilot)` → `GitHub Copilot (VS Code)` in the config table
- Added a note: *VS Code itself does not support MCP natively; MCP support is provided through the GitHub Copilot extension.*

### `README.md`
- `Cursor, Windsurf, VS Code` → `Cursor, Windsurf, GitHub Copilot (VS Code)`

## Principles
- Internal code identifiers (`'vscode'`, file paths like `.vscode/`) remain unchanged — they refer to actual VS Code paths
- Only user-facing labels and documentation text are corrected
- Files referenced in the task spec that don't exist (`README.en.md`, `AGENT-INSTALL.md`) were skipped