### PR TITLE
fix: correct plugin source paths in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "author": {
         "name": "yuque"
       },
-      "source": "personal",
+      "source": "./plugins/claude-code/personal",
       "category": "productivity"
     },
     {
@@ -28,7 +28,7 @@
       "author": {
         "name": "yuque"
       },
-      "source": "group",
+      "source": "./plugins/claude-code/group",
       "category": "productivity"
     }
   ]


### PR DESCRIPTION
## Problem

Fixes #42 

Users reported installation error when adding the marketplace:
```
Error: Failed to parse marketplace file at .claude-plugin/marketplace.json: Invalid schema
plugins.0.source: Invalid input, plugins.1.source: Invalid input
```

## Root Cause

The `source` field in `marketplace.json` was set to plugin names (`"personal"`, `"group"`) instead of relative paths to plugin directories.

Claude Code's schema requires `source` to be a **relative path** pointing to the actual plugin directory.

## Changes

- ✅ Changed `source: "personal"` → `source: "./plugins/claude-code/personal"`
- ✅ Changed `source: "group"` → `source: "./plugins/claude-code/group"`

## Testing

Verified directory structure:
```
plugins/claude-code/
├── personal/
│   ├── .claude-plugin/
│   └── skills/
└── group/
    ├── .claude-plugin/
    └── skills/
```

The paths now correctly point to the plugin directories containing `.claude-plugin/` and `skills/`.

## Impact

- Users can now successfully install plugins via `/plugin marketplace add yuque/yuque-ecosystem`
- No breaking changes to existing functionality
