### PR TITLE
fix: add ./ prefix to source paths in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "author": {
         "name": "yuque"
       },
-      "source": "plugins/claude-code/personal",
+      "source": "./plugins/claude-code/personal",
       "category": "productivity"
     },
     {
@@ -25,7 +25,7 @@
       "author": {
         "name": "yuque"
       },
-      "source": "plugins/claude-code/group",
+      "source": "./plugins/claude-code/group",
       "category": "productivity"
     }
   ]


### PR DESCRIPTION
## Problem

Fixes #42 (final fix after PR#44 and PR#45)

Users still report schema validation errors when adding the marketplace:
```
Error: Failed to parse marketplace file:
plugins.0.source: Invalid input
plugins.1.source: Invalid input
```

## Root Cause

The `source` field format was incorrect. According to Claude Code's official marketplace schema (verified by comparing with `claude-plugins-official` marketplace), the `source` field **must start with `./`** (relative path prefix).

**Current (incorrect):**
```json
{
  "source": "plugins/claude-code/personal"  // ❌ Missing ./ prefix
}
```

**Correct format (from official marketplace):**
```json
{
  "source": "./plugins/typescript-lsp"  // ✅ Must start with ./
}
```

## Changes

- ✅ Changed `source: "plugins/claude-code/personal"` → `source: "./plugins/claude-code/personal"`
- ✅ Changed `source: "plugins/claude-code/group"` → `source: "./plugins/claude-code/group"`

## Verification

Compared with official Claude Code marketplace:
```bash
# Official marketplace format
cat ~/.claude/plugins/marketplaces/claude-plugins-official/.claude-plugin/marketplace.json | jq '.plugins[0].source'
# Output: "./plugins/typescript-lsp" ✅

# Our format (after this fix)
cat .claude-plugin/marketplace.json | jq '.plugins[0].source'
# Output: "./plugins/claude-code/personal" ✅
```

Verified paths exist:
```bash
ls ./plugins/claude-code/personal/.claude-plugin/plugin.json  # ✅ Found
ls ./plugins/claude-code/group/.claude-plugin/plugin.json     # ✅ Found
```

## How to Use (After Merge)

1. **Remove the broken marketplace:**
   ```bash
   rm -rf ~/.claude/plugins/marketplaces/yuque-yuque-ecosystem
   ```

2. **Add the marketplace:**
   ```bash
   /plugin marketplace add yuque/yuque-ecosystem
   ```

3. **Install plugins:**
   ```bash
   /plugin install yuque-personal@yuque
   # or
   /plugin install yuque-group@yuque
   ```

Both commands should now work correctly! 🎉

## Related

- PR#44: First attempt (removed `pluginRoot`, but kept wrong path format)
- PR#45: Second attempt (removed `./` prefix by mistake)
- This PR: Final fix (adds `./` prefix as required by schema)
