### PR TITLE
docs: update plugin paths in claude-code README files

### DIFF
--- a/plugins/claude-code/README.en.md
+++ b/plugins/claude-code/README.en.md
@@ -10,13 +10,13 @@
 
 AI-powered personal knowledge base integration — 25 MCP Tools + 8 Skills.
 
-📂 [`personal/`](./personal/)
+📂 [`../yuque-personal/`](../yuque-personal/)
 
 ### Group (Team)
 
 AI-powered team knowledge base integration — 25 MCP Tools + 6 Skills.
 
-📂 [`group/`](./group/)
+📂 [`../yuque-group/`](../yuque-group/)
 
 ## Installation
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -10,13 +10,13 @@
 
 Personal knowledge base AI integration — 25 MCP Tools + 8 Skills.
 
-📂 [`personal/`](./personal/)
+📂 [`../yuque-personal/`](../yuque-personal/)
 
 ### Group (团队版)
 
 Team knowledge base AI integration — 25 MCP Tools + 6 Skills.
 
-📂 [`group/`](./group/)
+📂 [`../yuque-group/`](../yuque-group/)
 
 ## Installation
 


### PR DESCRIPTION
## Changes

After directory restructuring in PR#47, the `plugins/claude-code/README.md` and `README.en.md` still referenced the old paths. This PR updates the links to point to the new locations.

**Updated paths:**
- `plugins/claude-code/personal/` → `plugins/yuque-personal/`
- `plugins/claude-code/group/` → `plugins/yuque-group/`

## Context

PR#47 moved the plugin directories to match Claude Code's naming convention (plugin name must match the last segment of the source path). The `plugins/claude-code/` directory now serves as a documentation hub for Claude Code integration.

## Verification

Links now correctly point to:
- [`../yuque-personal/`](../yuque-personal/)
- [`../yuque-group/`](../yuque-group/)
