### PR TITLE
fix: add explicit skills path declaration to plugin manifests

### DIFF
--- a/plugins/yuque-group/.claude-plugin/plugin.json
+++ b/plugins/yuque-group/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "yuque-group",
   "description": "语雀团队版 — 团队知识库 AI 集成，25 MCP Tools + 6 Skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",
   "repository": "https://github.com/yuque/yuque-plugin",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./skills/"
 }

--- a/plugins/yuque-personal/.claude-plugin/plugin.json
+++ b/plugins/yuque-personal/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "yuque-personal",
-  "description": "语雀个人版 — 个人知识库 AI 集成，25 MCP Tools + 4 Skills",
-  "version": "1.0.0",
+  "description": "语雀个人版 — 个人知识库 AI 集成，25 MCP Tools + 8 Skills",
+  "version": "1.0.1",
   "author": {
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",
   "repository": "https://github.com/yuque/yuque-plugin",
-  "license": "MIT"
+  "license": "MIT",
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Problem

When installing yuque-personal or yuque-group plugins via the Claude Code marketplace (`/plugin marketplace add yuque/yuque-ecosystem`), only MCP servers are synced — skills are not installed.

## Root Cause

Both `plugins/yuque-personal/.claude-plugin/plugin.json` and `plugins/yuque-group/.claude-plugin/plugin.json` lacked an explicit `skills` path declaration. While the `skills/` directories existed with proper `SKILL.md` files, Claude Code's marketplace installation requires the manifest to explicitly declare component paths for reliable discovery.

## Changes

- Add `"skills": "./skills/"` to `plugins/yuque-personal/.claude-plugin/plugin.json`
- Add `"skills": "./skills/"` to `plugins/yuque-group/.claude-plugin/plugin.json`
- Fix yuque-personal description: "4 Skills" → "8 Skills" (there are actually 8 skills)
- Bump both plugin versions to 1.0.1

### Skills included

**yuque-personal** (8 skills):
- daily-capture, knowledge-connect, note-refine, reading-digest
- smart-search, smart-summary, stale-detector, style-extract

**yuque-group** (6 skills):
- knowledge-report, meeting-notes, onboarding-guide
- smart-search, tech-design, weekly-report

## References

- [Claude Code Plugin Manifest Schema](https://code.claude.com/docs/en/plugins-reference#plugin-manifest-schema)

Closes #58