### PR TITLE
fix: resolve website issues - deprecated tools, broken links, missing install guides

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "yuque-personal",
-      "description": "语雀个人版 — 个人知识库 AI 集成，25 MCP Tools + 4 Skills",
+      "description": "语雀个人版 — 个人知识库 AI 集成，16 MCP Tools + 8 Skills",
       "version": "1.0.0",
       "author": {
         "name": "yuque"
@@ -20,7 +20,7 @@
     },
     {
       "name": "yuque-group",
-      "description": "语雀团队版 — 团队知识库 AI 集成，25 MCP Tools + 6 Skills",
+      "description": "语雀团队版 — 团队知识库 AI 集成，16 MCP Tools + 6 Skills",
       "version": "1.0.0",
       "author": {
         "name": "yuque"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions
-    url: https://github.com/yuque/yuque-ecosystem/discussions/categories/q-a
+    url: https://github.com/yuque/yuque-ecosystem/issues
     about: Ask questions and get help from the community.
-  - name: Feature Requests
-    url: https://github.com/yuque/yuque-ecosystem/discussions/categories/ideas
-    about: Suggest new features or improvements.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected Area
+      description: Which part of the ecosystem would this feature apply to?
+      options:
+        - MCP Server (yuque-mcp)
+        - Website
+        - Claude Code Plugin
+        - OpenClaw Plugin
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references?
+    validations:
+      required: false

--- a/README.en.md
+++ b/README.en.md
@@ -25,11 +25,11 @@ yuque-ecosystem/
 ├── website/                  # Official website (GitHub Pages)
 ├── plugins/
 │   ├── claude-code/          # Claude Code Plugin (Marketplace)
-│   │   ├── personal/         # Personal edition — 25 Tools + 8 Skills
-│   │   └── group/            # Team edition — 25 Tools + 6 Skills
+│   │   ├── personal/         # Personal edition — 16 Tools + 8 Skills
+│   │   └── group/            # Team edition — 16 Tools + 6 Skills
 │   ├── opencode/             # OpenCode Plugin (MCP + Skills)
-│   │   ├── personal/         # Personal edition — 25 Tools + 8 Skills
-│   │   └── group/            # Team edition — 25 Tools + 6 Skills
+│   │   ├── personal/         # Personal edition — 16 Tools + 8 Skills
+│   │   └── group/            # Team edition — 16 Tools + 6 Skills
 │   └── openclaw/             # OpenClaw Plugin (Agent Skills)
 ├── shared/
 │   └── mcp-config/           # MCP config templates for various editors

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ yuque-ecosystem/
 ├── website/                  # Official website (GitHub Pages)
 ├── plugins/
 │   ├── claude-code/          # Claude Code Plugin (Marketplace)
-│   │   ├── personal/         # Personal edition — 25 Tools + 8 Skills
-│   │   └── group/            # Team edition — 25 Tools + 6 Skills
+│   │   ├── personal/         # Personal edition — 16 Tools + 8 Skills
+│   │   └── group/            # Team edition — 16 Tools + 6 Skills
 │   ├── opencode/             # OpenCode Plugin (MCP + Skills)
-│   │   ├── personal/         # Personal edition — 25 Tools + 8 Skills
-│   │   └── group/            # Team edition — 25 Tools + 6 Skills
+│   │   ├── personal/         # Personal edition — 16 Tools + 8 Skills
+│   │   └── group/            # Team edition — 16 Tools + 6 Skills
 │   └── openclaw/             # OpenClaw Plugin (Agent Skills)
 ├── shared/
 │   └── mcp-config/           # MCP config templates for various editors

--- a/plugins/claude-code/.claude-plugin/marketplace.json
+++ b/plugins/claude-code/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
   "plugins": [
     {
       "name": "yuque-personal",
-      "description": "语雀个人版 — 个人知识库 AI 集成，25 MCP Tools + 4 Skills",
+      "description": "语雀个人版 — 个人知识库 AI 集成，16 MCP Tools + 8 Skills",
       "version": "1.0.0",
       "author": {
         "name": "yuque"
@@ -23,7 +23,7 @@
     },
     {
       "name": "yuque-group",
-      "description": "语雀团队版 — 团队知识库 AI 集成，25 MCP Tools + 6 Skills",
+      "description": "语雀团队版 — 团队知识库 AI 集成，16 MCP Tools + 6 Skills",
       "version": "1.0.0",
       "author": {
         "name": "yuque"

--- a/plugins/claude-code/AGENT-INSTALL.md
+++ b/plugins/claude-code/AGENT-INSTALL.md
@@ -60,7 +60,7 @@ export YUQUE_TOKEN="your_token_here"
 
 ## Installation Method 2: MCP Server Only
 
-Use this if you only need the 25 MCP tools without skills, or if the marketplace is unavailable.
+Use this if you only need the 16 MCP tools without skills, or if the marketplace is unavailable.
 
 ### Install
 
@@ -93,7 +93,7 @@ After either installation method, verify the integration is working:
 ```bash
 claude mcp list
 # Look for "yuque-mcp" in the output
-# Should show ~25 tools available
+# Should show ~16 tools available
 ```
 
 ### Test 2: Quick Functional Test
@@ -126,15 +126,16 @@ cd /path/to/yuque-ecosystem
 
 ## Available After Installation
 
-### MCP Tools (25)
+### MCP Tools (16)
 
 | Category | Tools |
 |----------|-------|
-| Document Management | `yuque_search`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc`, `yuque_delete_doc`, `yuque_get_doc_history` |
-| Knowledge Base | `yuque_list_repos`, `yuque_get_repo`, `yuque_create_repo`, `yuque_update_repo`, `yuque_delete_repo`, `yuque_get_toc` |
-| User & Group | `yuque_get_user`, `yuque_list_groups`, `yuque_get_group`, `yuque_list_group_repos` |
-| Collaboration | `yuque_list_comments`, `yuque_create_comment`, `yuque_delete_comment` |
-| Statistics | `yuque_get_doc_stats`, `yuque_get_repo_stats`, `yuque_get_group_stats`, `yuque_get_group_member_stats`, `yuque_get_trending_docs`, `yuque_get_active_members` |
+| User | `yuque_get_user` |
+| Search | `yuque_search` |
+| Books (知识库) | `yuque_list_books`, `yuque_get_book`, `yuque_create_book`, `yuque_update_book` |
+| Docs | `yuque_list_docs`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc` |
+| TOC | `yuque_get_toc`, `yuque_update_toc` |
+| Notes (小记) | `yuque_list_notes`, `yuque_get_note`, `yuque_create_note`, `yuque_update_note` |
 
 ### Skills (Marketplace install only)
 

--- a/plugins/claude-code/README.en.md
+++ b/plugins/claude-code/README.en.md
@@ -8,13 +8,13 @@
 
 ### Personal
 
-AI-powered personal knowledge base integration — 25 MCP Tools + 8 Skills.
+AI-powered personal knowledge base integration — 16 MCP Tools + 8 Skills.
 
 📂 [`../yuque-personal/`](../yuque-personal/)
 
 ### Group (Team)
 
-AI-powered team knowledge base integration — 25 MCP Tools + 6 Skills.
+AI-powered team knowledge base integration — 16 MCP Tools + 6 Skills.
 
 📂 [`../yuque-group/`](../yuque-group/)
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -8,13 +8,13 @@
 
 ### Personal (个人版)
 
-Personal knowledge base AI integration — 25 MCP Tools + 8 Skills.
+Personal knowledge base AI integration — 16 MCP Tools + 8 Skills.
 
 📂 [`../yuque-personal/`](../yuque-personal/)
 
 ### Group (团队版)
 
-Team knowledge base AI integration — 25 MCP Tools + 6 Skills.
+Team knowledge base AI integration — 16 MCP Tools + 6 Skills.
 
 📂 [`../yuque-group/`](../yuque-group/)
 

--- a/plugins/openclaw/skills/daily-capture/SKILL.md
+++ b/plugins/openclaw/skills/daily-capture/SKILL.md
@@ -27,7 +27,7 @@ All tools are from the `yuque-mcp` server:
 - `yuque_get_doc` — Read existing capture log or thematic notes
 - `yuque_create_doc` — Create new capture log or thematic notes
 - `yuque_update_doc` — Append to capture log or update thematic notes
-- `yuque_list_repos` — List knowledge bases to find the target repo
+- `yuque_list_books` — List knowledge bases to find the target repo
 
 ## Workflow
 
@@ -209,7 +209,7 @@ Confirm: "主题笔记「[主题标题]」已保存到「[知识库名称]」：
 |-----------|--------|
 | Document not found (404) | Create a new capture log for today |
 | Permission denied (403) | Tell user they may lack permission to access or edit this document |
-| Target repo not found | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Present the capture/note in chat and suggest manual saving |
 | No captures found for organization | Inform user: "最近没有找到碎片记录，先随手记几条吧！" |
 | Capture content is empty | Ask user: "你想记录什么？" |

--- a/plugins/openclaw/skills/knowledge-connect/SKILL.md
+++ b/plugins/openclaw/skills/knowledge-connect/SKILL.md
@@ -24,8 +24,8 @@ Analyze documents in your Yuque knowledge base, find hidden connections between 
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List all documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_doc` — Read document content for analysis
 - `yuque_search` — Search for potentially related documents
 - `yuque_update_doc` — Add cross-reference links to documents
@@ -48,13 +48,13 @@ User wants cross-repo connections. Analyze documents across multiple repos.
 For Case B/C, first list available repos:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 Then list documents in the target repo(s):
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/plugins/openclaw/skills/reading-digest/SKILL.md
+++ b/plugins/openclaw/skills/reading-digest/SKILL.md
@@ -24,7 +24,7 @@ Read an article or document, extract core insights, golden quotes, and action it
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content
-- `yuque_list_repos` — List user's knowledge bases (to find the target repo for saving)
+- `yuque_list_books` — List user's knowledge bases (to find the target repo for saving)
 - `yuque_create_doc` — Create a new document (to save reading notes)
 - `yuque_search` — Search for existing reading notes to avoid duplicates
 
@@ -161,6 +161,6 @@ If the user doesn't want to save, just present the reading notes in the chat.
 | Document not found (404) | Inform user the document may have been deleted or the link is incorrect |
 | Permission denied (403) | Tell user they may lack permission to access this document |
 | Document content is empty | Inform user: "该文档内容为空，无法生成阅读笔记" |
-| Target repo not found when saving | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found when saving | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Inform user the save failed, present the notes in chat instead |
 | Article is not text-based (e.g., pure images) | Inform user: "该文档主要是图片内容，无法提取文字进行分析" |

--- a/plugins/openclaw/skills/smart-summary/SKILL.md
+++ b/plugins/openclaw/skills/smart-summary/SKILL.md
@@ -24,7 +24,7 @@ Generate summaries at different granularity levels for any Yuque document or ent
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content by slug/id
-- `yuque_get_repo` — Get knowledge base metadata
+- `yuque_get_book` — Get knowledge base metadata
 - `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_toc` — Get the table of contents of a knowledge base
 

--- a/plugins/openclaw/skills/stale-detector/SKILL.md
+++ b/plugins/openclaw/skills/stale-detector/SKILL.md
@@ -23,7 +23,7 @@ Scan a Yuque knowledge base to discover documents that haven't been updated in a
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
+- `yuque_list_books` — List user's knowledge bases
 - `yuque_list_docs` — List all documents in a knowledge base with metadata
 - `yuque_get_doc` — Read document content for staleness analysis
 - `yuque_get_toc` — Get knowledge base structure
@@ -39,7 +39,7 @@ Extract `repo_id` (namespace) from the provided link or name.
 List all repos first:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   user_id: "<user_id>"
 ```
@@ -190,7 +190,7 @@ These are suggestions only — do not take action without user confirmation.
 
 | Situation | Action |
 |-----------|--------|
-| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_repos` |
+| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_books` |
 | Knowledge base is empty | Inform user: "这个知识库目前没有文档，无需体检" |
 | `yuque_list_docs` returns error | Inform user of the issue, suggest checking the knowledge base link |
 | Too many documents (100+) | Analyze metadata for all, but only deep-read the top 10 stalest documents |

--- a/plugins/openclaw/skills/style-extract/SKILL.md
+++ b/plugins/openclaw/skills/style-extract/SKILL.md
@@ -24,8 +24,8 @@ Analyze your existing Yuque documents to extract your unique writing style — v
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List documents in a knowledge base
 - `yuque_get_doc` — Read document content for style analysis
 - `yuque_search` — Find specific types of documents for analysis
 - `yuque_create_doc` — Save the style profile as a document
@@ -46,11 +46,11 @@ User specifies a knowledge base. Sample documents from it.
 If the user isn't sure, search for their most substantial documents:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/plugins/opencode/AGENT-INSTALL.md
+++ b/plugins/opencode/AGENT-INSTALL.md
@@ -195,15 +195,16 @@ Expected: Returns matching documents from your Yuque knowledge base.
 
 ## Available After Installation
 
-### MCP Tools (25)
+### MCP Tools (16)
 
 | Category | Tools |
 |----------|-------|
-| Document Management | `yuque_search`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc`, `yuque_delete_doc`, `yuque_get_doc_history` |
-| Knowledge Base | `yuque_list_repos`, `yuque_get_repo`, `yuque_create_repo`, `yuque_update_repo`, `yuque_delete_repo`, `yuque_get_toc` |
-| User & Group | `yuque_get_user`, `yuque_list_groups`, `yuque_get_group`, `yuque_list_group_repos` |
-| Collaboration | `yuque_list_comments`, `yuque_create_comment`, `yuque_delete_comment` |
-| Statistics | `yuque_get_doc_stats`, `yuque_get_repo_stats`, `yuque_get_group_stats`, `yuque_get_group_member_stats`, `yuque_get_trending_docs`, `yuque_get_active_members` |
+| User | `yuque_get_user` |
+| Search | `yuque_search` |
+| Books (知识库) | `yuque_list_books`, `yuque_get_book`, `yuque_create_book`, `yuque_update_book` |
+| Docs | `yuque_list_docs`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc` |
+| TOC | `yuque_get_toc`, `yuque_update_toc` |
+| Notes (小记) | `yuque_list_notes`, `yuque_get_note`, `yuque_create_note`, `yuque_update_note` |
 
 ### Personal Skills (8)
 

--- a/plugins/opencode/README.en.md
+++ b/plugins/opencode/README.en.md
@@ -4,19 +4,19 @@
 
 > Yuque AI Ecosystem — MCP Tools and Skills for [OpenCode](https://opencode.ai)
 
-Integrate your Yuque knowledge base with OpenCode — the open-source AI coding agent. Get 25 MCP tools for document management and 14 ready-to-use skills for knowledge workflows.
+Integrate your Yuque knowledge base with OpenCode — the open-source AI coding agent. Get 16 MCP tools for document management and 14 ready-to-use skills for knowledge workflows.
 
 ## Editions
 
 ### Personal
 
-AI-powered personal knowledge base integration — 25 MCP Tools + 8 Skills.
+AI-powered personal knowledge base integration — 16 MCP Tools + 8 Skills.
 
 📂 [`personal/`](./personal/)
 
 ### Group (Team)
 
-AI-powered team knowledge base integration — 25 MCP Tools + 6 Skills.
+AI-powered team knowledge base integration — 16 MCP Tools + 6 Skills.
 
 📂 [`group/`](./group/)
 
@@ -69,7 +69,7 @@ opencode mcp list
 opencode mcp debug yuque
 ```
 
-Once connected, all 25 yuque-mcp tools will be available to the AI agent.
+Once connected, all 16 yuque-mcp tools will be available to the AI agent.
 
 ---
 
@@ -146,54 +146,49 @@ After installation, OpenCode will automatically discover the skills. The agent c
 
 ---
 
-## Available MCP Tools (25)
+## Available MCP Tools (16)
 
-The `yuque-mcp` server provides 25 tools across these categories:
+The `yuque-mcp` server provides 16 tools across these categories:
 
-### Document Management
+### User
 | Tool | Description |
 |------|-------------|
-| `yuque_search` | Search documents by keyword |
-| `yuque_get_doc` | Get document content by ID/slug |
-| `yuque_create_doc` | Create a new document |
-| `yuque_update_doc` | Update document content |
-| `yuque_delete_doc` | Delete a document |
-| `yuque_get_doc_history` | Get document revision history |
+| `yuque_get_user` | Get current authenticated user information |
 
-### Repository (Knowledge Base) Management
+### Search
 | Tool | Description |
 |------|-------------|
-| `yuque_list_repos` | List accessible knowledge bases |
-| `yuque_get_repo` | Get knowledge base details |
-| `yuque_create_repo` | Create a new knowledge base |
-| `yuque_update_repo` | Update knowledge base settings |
-| `yuque_delete_repo` | Delete a knowledge base |
-| `yuque_get_toc` | Get table of contents |
+| `yuque_search` | Search for documents or repos in Yuque |
 
-### User & Group
+### Books (知识库)
 | Tool | Description |
 |------|-------------|
-| `yuque_get_user` | Get current user info |
-| `yuque_list_groups` | List groups the user belongs to |
-| `yuque_get_group` | Get group details |
-| `yuque_list_group_repos` | List repos in a group |
+| `yuque_list_books` | List all books for the current user |
+| `yuque_get_book` | Get a specific book by ID or namespace |
+| `yuque_create_book` | Create a new book |
+| `yuque_update_book` | Update a book |
 
-### Collaboration
+### Docs
 | Tool | Description |
 |------|-------------|
-| `yuque_list_comments` | List document comments |
-| `yuque_create_comment` | Add a comment to a document |
-| `yuque_delete_comment` | Delete a comment |
+| `yuque_list_docs` | List all documents in a book |
+| `yuque_get_doc` | Get a specific document with full content |
+| `yuque_create_doc` | Create a new document in a book |
+| `yuque_update_doc` | Update an existing document |
 
-### Statistics
+### TOC
 | Tool | Description |
 |------|-------------|
-| `yuque_get_doc_stats` | Get document view/read stats |
-| `yuque_get_repo_stats` | Get repo-level statistics |
-| `yuque_get_group_stats` | Get group-level statistics |
-| `yuque_get_group_member_stats` | Get group member contribution stats |
-| `yuque_get_trending_docs` | Get trending documents |
-| `yuque_get_active_members` | Get most active members |
+| `yuque_get_toc` | Get the table of contents for a book |
+| `yuque_update_toc` | Update the table of contents for a book |
+
+### Notes (小记)
+| Tool | Description |
+|------|-------------|
+| `yuque_list_notes` | List all notes with pagination |
+| `yuque_get_note` | Get a specific note with full content |
+| `yuque_create_note` | Create a new note |
+| `yuque_update_note` | Update an existing note |
 
 ---
 

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -4,19 +4,19 @@
 
 > 语雀 AI 生态 — MCP Tools and Skills for [OpenCode](https://opencode.ai)
 
-Integrate your Yuque knowledge base with OpenCode — the open-source AI coding agent. Get 25 MCP tools for document management and 14 ready-to-use skills for knowledge workflows.
+Integrate your Yuque knowledge base with OpenCode — the open-source AI coding agent. Get 16 MCP tools for document management and 14 ready-to-use skills for knowledge workflows.
 
 ## Editions
 
 ### Personal (个人版)
 
-Personal knowledge base AI integration — 25 MCP Tools + 8 Skills.
+Personal knowledge base AI integration — 16 MCP Tools + 8 Skills.
 
 📂 [`personal/`](./personal/)
 
 ### Group (团队版)
 
-Team knowledge base AI integration — 25 MCP Tools + 6 Skills.
+Team knowledge base AI integration — 16 MCP Tools + 6 Skills.
 
 📂 [`group/`](./group/)
 
@@ -69,7 +69,7 @@ opencode mcp list
 opencode mcp debug yuque
 ```
 
-Once connected, all 25 yuque-mcp tools will be available to the AI agent.
+Once connected, all 16 yuque-mcp tools will be available to the AI agent.
 
 ---
 
@@ -146,54 +146,49 @@ After installation, OpenCode will automatically discover the skills. The agent c
 
 ---
 
-## Available MCP Tools (25)
+## Available MCP Tools (16)
 
-The `yuque-mcp` server provides 25 tools across these categories:
+The `yuque-mcp` server provides 16 tools across these categories:
 
-### Document Management
+### User
 | Tool | Description |
 |------|-------------|
-| `yuque_search` | Search documents by keyword |
-| `yuque_get_doc` | Get document content by ID/slug |
-| `yuque_create_doc` | Create a new document |
-| `yuque_update_doc` | Update document content |
-| `yuque_delete_doc` | Delete a document |
-| `yuque_get_doc_history` | Get document revision history |
+| `yuque_get_user` | Get current authenticated user information |
 
-### Repository (Knowledge Base) Management
+### Search
 | Tool | Description |
 |------|-------------|
-| `yuque_list_repos` | List accessible knowledge bases |
-| `yuque_get_repo` | Get knowledge base details |
-| `yuque_create_repo` | Create a new knowledge base |
-| `yuque_update_repo` | Update knowledge base settings |
-| `yuque_delete_repo` | Delete a knowledge base |
-| `yuque_get_toc` | Get table of contents |
+| `yuque_search` | Search for documents or repos in Yuque |
 
-### User & Group
+### Books (知识库)
 | Tool | Description |
 |------|-------------|
-| `yuque_get_user` | Get current user info |
-| `yuque_list_groups` | List groups the user belongs to |
-| `yuque_get_group` | Get group details |
-| `yuque_list_group_repos` | List repos in a group |
+| `yuque_list_books` | List all books for the current user |
+| `yuque_get_book` | Get a specific book by ID or namespace |
+| `yuque_create_book` | Create a new book |
+| `yuque_update_book` | Update a book |
 
-### Collaboration
+### Docs
 | Tool | Description |
 |------|-------------|
-| `yuque_list_comments` | List document comments |
-| `yuque_create_comment` | Add a comment to a document |
-| `yuque_delete_comment` | Delete a comment |
+| `yuque_list_docs` | List all documents in a book |
+| `yuque_get_doc` | Get a specific document with full content |
+| `yuque_create_doc` | Create a new document in a book |
+| `yuque_update_doc` | Update an existing document |
 
-### Statistics
+### TOC
 | Tool | Description |
 |------|-------------|
-| `yuque_get_doc_stats` | Get document view/read stats |
-| `yuque_get_repo_stats` | Get repo-level statistics |
-| `yuque_get_group_stats` | Get group-level statistics |
-| `yuque_get_group_member_stats` | Get group member contribution stats |
-| `yuque_get_trending_docs` | Get trending documents |
-| `yuque_get_active_members` | Get most active members |
+| `yuque_get_toc` | Get the table of contents for a book |
+| `yuque_update_toc` | Update the table of contents for a book |
+
+### Notes (小记)
+| Tool | Description |
+|------|-------------|
+| `yuque_list_notes` | List all notes with pagination |
+| `yuque_get_note` | Get a specific note with full content |
+| `yuque_create_note` | Create a new note |
+| `yuque_update_note` | Update an existing note |
 
 ---
 

--- a/plugins/opencode/group/skills/knowledge-report/SKILL.md
+++ b/plugins/opencode/group/skills/knowledge-report/SKILL.md
@@ -270,6 +270,6 @@ Parameters:
 | `yuque_group_stats` fails | Inform user, check group login and team Token |
 | Any stats API returns partial data | Generate report with available data, note gaps |
 | Group has very low activity | Still generate report, focus suggestions on how to improve |
-| User doesn't know group login | Help them find it via `yuque_list_repos` |
+| User doesn't know group login | Help them find it via `yuque_list_books` |
 | Multiple groups | Ask user which group to report on |
 | Team Token missing statistic:read | Inform user the Token needs `statistic:read` permission |

--- a/plugins/opencode/group/skills/meeting-notes/SKILL.md
+++ b/plugins/opencode/group/skills/meeting-notes/SKILL.md
@@ -22,7 +22,7 @@ Take raw meeting information from the user, format it into a standard meeting no
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List group knowledge bases to find the target repo
+- `yuque_list_books` — List group knowledge bases to find the target repo
 - `yuque_create_doc` — Create the meeting notes document
 
 ## Workflow
@@ -134,7 +134,7 @@ Use this template:
 List the team's knowledge bases:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -186,7 +186,7 @@ After creation, respond with:
 | Situation | Action |
 |-----------|--------|
 | User provides very little info | Ask for at least: topic, attendees, key decisions |
-| `yuque_list_repos` returns empty | Ask user to verify group login and group Token |
+| `yuque_list_books` returns empty | Ask user to verify group login and group Token |
 | `yuque_create_doc` fails (403) | Tell user they may lack write permission; check group Token scope |
 | `yuque_create_doc` fails (other) | Show error, suggest user check yuque-mcp connection |
 | No clear action items | Still create the doc, note "本次会议无明确待办事项" |

--- a/plugins/opencode/group/skills/onboarding-guide/SKILL.md
+++ b/plugins/opencode/group/skills/onboarding-guide/SKILL.md
@@ -22,7 +22,7 @@ Scan a team's Yuque knowledge bases, identify core documents, and generate a str
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List all knowledge bases in the team
+- `yuque_list_books` — List all knowledge bases in the team
 - `yuque_get_toc` — Get the table of contents for each knowledge base
 - `yuque_get_doc` — (Optional) Read specific docs for summary
 - `yuque_group_members` — Get group member list (for mentor assignment)
@@ -50,7 +50,7 @@ If the user doesn't specify a role, generate a general-purpose guide.
 #### 2a. List All Repos
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -249,7 +249,7 @@ Parameters:
 
 | Situation | Action |
 |-----------|--------|
-| `yuque_list_repos` returns empty | Ask user to verify group login and group Token |
+| `yuque_list_books` returns empty | Ask user to verify group login and group Token |
 | `yuque_get_toc` fails for a repo | Skip that repo, note it in the guide |
 | `yuque_group_members` fails | Skip mentor suggestion, still generate the guide |
 | Team has very few docs (<10) | Create a simpler guide, suggest the group build more docs |

--- a/plugins/opencode/group/skills/smart-search/SKILL.md
+++ b/plugins/opencode/group/skills/smart-search/SKILL.md
@@ -22,7 +22,7 @@ Search across group Yuque knowledge bases using natural language, read relevant 
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List group knowledge bases to determine search scope
+- `yuque_list_books` — List group knowledge bases to determine search scope
 - `yuque_search` — Search documents by keyword
 - `yuque_get_doc` — Read full document content by slug/id
 
@@ -33,7 +33,7 @@ All tools are from the `yuque-mcp` server:
 First, get the list of group knowledge bases to understand the search scope:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -130,7 +130,7 @@ Compose the answer in the following format:
 
 | Situation | Action |
 |-----------|--------|
-| `yuque_list_repos` fails | Check if group login is correct and group Token is configured |
+| `yuque_list_books` fails | Check if group login is correct and group Token is configured |
 | `yuque_search` returns empty | Try alternative keywords, then inform user |
 | `yuque_get_doc` fails (404) | Skip this doc, note it may have been deleted |
 | `yuque_get_doc` fails (403) | Tell user they may lack permission; check group Token scope |

--- a/plugins/opencode/group/skills/tech-design/SKILL.md
+++ b/plugins/opencode/group/skills/tech-design/SKILL.md
@@ -23,7 +23,7 @@ Help the user write a structured technical design document following a standard 
 All tools are from the `yuque-mcp` server:
 
 - `yuque_search` — (Optional) Search for related existing docs for context
-- `yuque_list_repos` — Find the target group knowledge base
+- `yuque_list_books` — Find the target group knowledge base
 - `yuque_create_doc` — Create the design document
 
 ## Reference
@@ -96,7 +96,7 @@ Present the draft to the user before saving. Ask:
 ### Step 5: Save to Team Yuque
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"

--- a/plugins/opencode/group/skills/weekly-report/SKILL.md
+++ b/plugins/opencode/group/skills/weekly-report/SKILL.md
@@ -24,7 +24,7 @@ All tools are from the `yuque-mcp` server:
 
 - `yuque_group_doc_stats` — Get document activity stats for a group
 - `yuque_group_member_stats` — Get member contribution stats for a group
-- `yuque_list_repos` — List repos in the group (for context)
+- `yuque_list_books` — List repos in the group (for context)
 - `yuque_create_doc` — Create the weekly report document
 
 ## Workflow
@@ -64,7 +64,7 @@ This returns: per-member doc count, word count, activity metrics.
 #### 2c. Repository List (for context)
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -194,6 +194,6 @@ Parameters:
 | `yuque_group_doc_stats` fails | Inform user, check if group login is correct and group Token is configured |
 | `yuque_group_member_stats` fails | Generate report without member breakdown, note the gap |
 | Group has no activity this week | Create a brief report noting zero activity, suggest reasons |
-| User doesn't know group login | Use `yuque_list_repos` with their personal login to find groups |
+| User doesn't know group login | Use `yuque_list_books` with their personal login to find groups |
 | API returns partial data | Generate report with available data, note what's missing |
 | Team Token missing statistic:read | Inform user the Token needs `statistic:read` permission |

--- a/plugins/opencode/personal/skills/daily-capture/SKILL.md
+++ b/plugins/opencode/personal/skills/daily-capture/SKILL.md
@@ -27,7 +27,7 @@ All tools are from the `yuque-mcp` server:
 - `yuque_get_doc` — Read existing capture log or thematic notes
 - `yuque_create_doc` — Create new capture log or thematic notes
 - `yuque_update_doc` — Append to capture log or update thematic notes
-- `yuque_list_repos` — List knowledge bases to find the target repo
+- `yuque_list_books` — List knowledge bases to find the target repo
 
 ## Workflow
 
@@ -209,7 +209,7 @@ Confirm: "主题笔记「[主题标题]」已保存到「[知识库名称]」：
 |-----------|--------|
 | Document not found (404) | Create a new capture log for today |
 | Permission denied (403) | Tell user they may lack permission to access or edit this document |
-| Target repo not found | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Present the capture/note in chat and suggest manual saving |
 | No captures found for organization | Inform user: "最近没有找到碎片记录，先随手记几条吧！" |
 | Capture content is empty | Ask user: "你想记录什么？" |

--- a/plugins/opencode/personal/skills/knowledge-connect/SKILL.md
+++ b/plugins/opencode/personal/skills/knowledge-connect/SKILL.md
@@ -24,8 +24,8 @@ Analyze documents in your Yuque knowledge base, find hidden connections between 
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List all documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_doc` — Read document content for analysis
 - `yuque_search` — Search for potentially related documents
 - `yuque_update_doc` — Add cross-reference links to documents
@@ -48,13 +48,13 @@ User wants cross-repo connections. Analyze documents across multiple repos.
 For Case B/C, first list available repos:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 Then list documents in the target repo(s):
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/plugins/opencode/personal/skills/reading-digest/SKILL.md
+++ b/plugins/opencode/personal/skills/reading-digest/SKILL.md
@@ -24,7 +24,7 @@ Read an article or document, extract core insights, golden quotes, and action it
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content
-- `yuque_list_repos` — List user's knowledge bases (to find the target repo for saving)
+- `yuque_list_books` — List user's knowledge bases (to find the target repo for saving)
 - `yuque_create_doc` — Create a new document (to save reading notes)
 - `yuque_search` — Search for existing reading notes to avoid duplicates
 
@@ -161,6 +161,6 @@ If the user doesn't want to save, just present the reading notes in the chat.
 | Document not found (404) | Inform user the document may have been deleted or the link is incorrect |
 | Permission denied (403) | Tell user they may lack permission to access this document |
 | Document content is empty | Inform user: "该文档内容为空，无法生成阅读笔记" |
-| Target repo not found when saving | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found when saving | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Inform user the save failed, present the notes in chat instead |
 | Article is not text-based (e.g., pure images) | Inform user: "该文档主要是图片内容，无法提取文字进行分析" |

--- a/plugins/opencode/personal/skills/smart-summary/SKILL.md
+++ b/plugins/opencode/personal/skills/smart-summary/SKILL.md
@@ -24,7 +24,7 @@ Generate summaries at different granularity levels for any Yuque document or ent
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content by slug/id
-- `yuque_get_repo` — Get knowledge base metadata
+- `yuque_get_book` — Get knowledge base metadata
 - `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_toc` — Get the table of contents of a knowledge base
 

--- a/plugins/opencode/personal/skills/stale-detector/SKILL.md
+++ b/plugins/opencode/personal/skills/stale-detector/SKILL.md
@@ -23,7 +23,7 @@ Scan a Yuque knowledge base to discover documents that haven't been updated in a
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
+- `yuque_list_books` — List user's knowledge bases
 - `yuque_list_docs` — List all documents in a knowledge base with metadata
 - `yuque_get_doc` — Read document content for staleness analysis
 - `yuque_get_toc` — Get knowledge base structure
@@ -39,7 +39,7 @@ Extract `repo_id` (namespace) from the provided link or name.
 List all repos first:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   user_id: "<user_id>"
 ```
@@ -190,7 +190,7 @@ These are suggestions only — do not take action without user confirmation.
 
 | Situation | Action |
 |-----------|--------|
-| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_repos` |
+| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_books` |
 | Knowledge base is empty | Inform user: "这个知识库目前没有文档，无需体检" |
 | `yuque_list_docs` returns error | Inform user of the issue, suggest checking the knowledge base link |
 | Too many documents (100+) | Analyze metadata for all, but only deep-read the top 10 stalest documents |

--- a/plugins/opencode/personal/skills/style-extract/SKILL.md
+++ b/plugins/opencode/personal/skills/style-extract/SKILL.md
@@ -24,8 +24,8 @@ Analyze your existing Yuque documents to extract your unique writing style — v
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List documents in a knowledge base
 - `yuque_get_doc` — Read document content for style analysis
 - `yuque_search` — Find specific types of documents for analysis
 - `yuque_create_doc` — Save the style profile as a document
@@ -46,11 +46,11 @@ User specifies a knowledge base. Sample documents from it.
 If the user isn't sure, search for their most substantial documents:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/plugins/yuque-group/.claude-plugin/plugin.json
+++ b/plugins/yuque-group/.claude-plugin/plugin.json
@@ -1,8 +1,10 @@
 {
   "name": "yuque-group",
-  "description": "语雀团队版 — 团队知识库 AI 集成，25 MCP Tools + 6 Skills",
+  "description": "语雀团队版 — 团队知识库 AI 集成，16 MCP Tools + 6 Skills",
   "version": "1.0.1",
   "author": {
+      "name": "yuque"
+    },
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",

--- a/plugins/yuque-group/README.md
+++ b/plugins/yuque-group/README.md
@@ -1,6 +1,6 @@
 # 语雀团队版 Plugin / Yuque Group Plugin
 
-团队知识库 AI 集成 — 25 MCP Tools + 6 Skills。
+团队知识库 AI 集成 — 16 MCP Tools + 6 Skills。
 
 ## Skills
 

--- a/plugins/yuque-group/skills/knowledge-report/SKILL.md
+++ b/plugins/yuque-group/skills/knowledge-report/SKILL.md
@@ -270,6 +270,6 @@ Parameters:
 | `yuque_group_stats` fails | Inform user, check group login and team Token |
 | Any stats API returns partial data | Generate report with available data, note gaps |
 | Group has very low activity | Still generate report, focus suggestions on how to improve |
-| User doesn't know group login | Help them find it via `yuque_list_repos` |
+| User doesn't know group login | Help them find it via `yuque_list_books` |
 | Multiple groups | Ask user which group to report on |
 | Team Token missing statistic:read | Inform user the Token needs `statistic:read` permission |

--- a/plugins/yuque-group/skills/meeting-notes/SKILL.md
+++ b/plugins/yuque-group/skills/meeting-notes/SKILL.md
@@ -22,7 +22,7 @@ Take raw meeting information from the user, format it into a standard meeting no
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List group knowledge bases to find the target repo
+- `yuque_list_books` — List group knowledge bases to find the target repo
 - `yuque_create_doc` — Create the meeting notes document
 
 ## Workflow
@@ -134,7 +134,7 @@ Use this template:
 List the team's knowledge bases:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -186,7 +186,7 @@ After creation, respond with:
 | Situation | Action |
 |-----------|--------|
 | User provides very little info | Ask for at least: topic, attendees, key decisions |
-| `yuque_list_repos` returns empty | Ask user to verify group login and group Token |
+| `yuque_list_books` returns empty | Ask user to verify group login and group Token |
 | `yuque_create_doc` fails (403) | Tell user they may lack write permission; check group Token scope |
 | `yuque_create_doc` fails (other) | Show error, suggest user check yuque-mcp connection |
 | No clear action items | Still create the doc, note "本次会议无明确待办事项" |

--- a/plugins/yuque-group/skills/onboarding-guide/SKILL.md
+++ b/plugins/yuque-group/skills/onboarding-guide/SKILL.md
@@ -22,7 +22,7 @@ Scan a team's Yuque knowledge bases, identify core documents, and generate a str
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List all knowledge bases in the team
+- `yuque_list_books` — List all knowledge bases in the team
 - `yuque_get_toc` — Get the table of contents for each knowledge base
 - `yuque_get_doc` — (Optional) Read specific docs for summary
 - `yuque_group_members` — Get group member list (for mentor assignment)
@@ -50,7 +50,7 @@ If the user doesn't specify a role, generate a general-purpose guide.
 #### 2a. List All Repos
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -249,7 +249,7 @@ Parameters:
 
 | Situation | Action |
 |-----------|--------|
-| `yuque_list_repos` returns empty | Ask user to verify group login and group Token |
+| `yuque_list_books` returns empty | Ask user to verify group login and group Token |
 | `yuque_get_toc` fails for a repo | Skip that repo, note it in the guide |
 | `yuque_group_members` fails | Skip mentor suggestion, still generate the guide |
 | Team has very few docs (<10) | Create a simpler guide, suggest the group build more docs |

--- a/plugins/yuque-group/skills/smart-search/SKILL.md
+++ b/plugins/yuque-group/skills/smart-search/SKILL.md
@@ -22,7 +22,7 @@ Search across group Yuque knowledge bases using natural language, read relevant 
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List group knowledge bases to determine search scope
+- `yuque_list_books` — List group knowledge bases to determine search scope
 - `yuque_search` — Search documents by keyword
 - `yuque_get_doc` — Read full document content by slug/id
 
@@ -33,7 +33,7 @@ All tools are from the `yuque-mcp` server:
 First, get the list of group knowledge bases to understand the search scope:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -130,7 +130,7 @@ Compose the answer in the following format:
 
 | Situation | Action |
 |-----------|--------|
-| `yuque_list_repos` fails | Check if group login is correct and group Token is configured |
+| `yuque_list_books` fails | Check if group login is correct and group Token is configured |
 | `yuque_search` returns empty | Try alternative keywords, then inform user |
 | `yuque_get_doc` fails (404) | Skip this doc, note it may have been deleted |
 | `yuque_get_doc` fails (403) | Tell user they may lack permission; check group Token scope |

--- a/plugins/yuque-group/skills/tech-design/SKILL.md
+++ b/plugins/yuque-group/skills/tech-design/SKILL.md
@@ -23,7 +23,7 @@ Help the user write a structured technical design document following a standard 
 All tools are from the `yuque-mcp` server:
 
 - `yuque_search` — (Optional) Search for related existing docs for context
-- `yuque_list_repos` — Find the target group knowledge base
+- `yuque_list_books` — Find the target group knowledge base
 - `yuque_create_doc` — Create the design document
 
 ## Reference
@@ -96,7 +96,7 @@ Present the draft to the user before saving. Ask:
 ### Step 5: Save to Team Yuque
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"

--- a/plugins/yuque-group/skills/weekly-report/SKILL.md
+++ b/plugins/yuque-group/skills/weekly-report/SKILL.md
@@ -24,7 +24,7 @@ All tools are from the `yuque-mcp` server:
 
 - `yuque_group_doc_stats` — Get document activity stats for a group
 - `yuque_group_member_stats` — Get member contribution stats for a group
-- `yuque_list_repos` — List repos in the group (for context)
+- `yuque_list_books` — List repos in the group (for context)
 - `yuque_create_doc` — Create the weekly report document
 
 ## Workflow
@@ -64,7 +64,7 @@ This returns: per-member doc count, word count, activity metrics.
 #### 2c. Repository List (for context)
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   login: "<group_login>"
   type: "group"
@@ -194,6 +194,6 @@ Parameters:
 | `yuque_group_doc_stats` fails | Inform user, check if group login is correct and group Token is configured |
 | `yuque_group_member_stats` fails | Generate report without member breakdown, note the gap |
 | Group has no activity this week | Create a brief report noting zero activity, suggest reasons |
-| User doesn't know group login | Use `yuque_list_repos` with their personal login to find groups |
+| User doesn't know group login | Use `yuque_list_books` with their personal login to find groups |
 | API returns partial data | Generate report with available data, note what's missing |
 | Team Token missing statistic:read | Inform user the Token needs `statistic:read` permission |

--- a/plugins/yuque-personal/.claude-plugin/plugin.json
+++ b/plugins/yuque-personal/.claude-plugin/plugin.json
@@ -1,8 +1,10 @@
 {
   "name": "yuque-personal",
-  "description": "语雀个人版 — 个人知识库 AI 集成，25 MCP Tools + 8 Skills",
+  "description": "语雀个人版 — 个人知识库 AI 集成，16 MCP Tools + 8 Skills",
   "version": "1.0.1",
   "author": {
+      "name": "yuque"
+    },
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",

--- a/plugins/yuque-personal/README.md
+++ b/plugins/yuque-personal/README.md
@@ -1,6 +1,6 @@
 # 语雀个人版 Plugin / Yuque Personal Plugin
 
-个人知识库 AI 集成 — 25 MCP Tools + 8 Skills。
+个人知识库 AI 集成 — 16 MCP Tools + 8 Skills。
 
 语雀 = 第二大脑，Skills = AI 认知能力。
 

--- a/plugins/yuque-personal/skills/daily-capture/SKILL.md
+++ b/plugins/yuque-personal/skills/daily-capture/SKILL.md
@@ -27,7 +27,7 @@ All tools are from the `yuque-mcp` server:
 - `yuque_get_doc` — Read existing capture log or thematic notes
 - `yuque_create_doc` — Create new capture log or thematic notes
 - `yuque_update_doc` — Append to capture log or update thematic notes
-- `yuque_list_repos` — List knowledge bases to find the target repo
+- `yuque_list_books` — List knowledge bases to find the target repo
 
 ## Workflow
 
@@ -209,7 +209,7 @@ Confirm: "主题笔记「[主题标题]」已保存到「[知识库名称]」：
 |-----------|--------|
 | Document not found (404) | Create a new capture log for today |
 | Permission denied (403) | Tell user they may lack permission to access or edit this document |
-| Target repo not found | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Present the capture/note in chat and suggest manual saving |
 | No captures found for organization | Inform user: "最近没有找到碎片记录，先随手记几条吧！" |
 | Capture content is empty | Ask user: "你想记录什么？" |

--- a/plugins/yuque-personal/skills/knowledge-connect/SKILL.md
+++ b/plugins/yuque-personal/skills/knowledge-connect/SKILL.md
@@ -24,8 +24,8 @@ Analyze documents in your Yuque knowledge base, find hidden connections between 
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List all documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_doc` — Read document content for analysis
 - `yuque_search` — Search for potentially related documents
 - `yuque_update_doc` — Add cross-reference links to documents
@@ -48,13 +48,13 @@ User wants cross-repo connections. Analyze documents across multiple repos.
 For Case B/C, first list available repos:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 Then list documents in the target repo(s):
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/plugins/yuque-personal/skills/reading-digest/SKILL.md
+++ b/plugins/yuque-personal/skills/reading-digest/SKILL.md
@@ -24,7 +24,7 @@ Read an article or document, extract core insights, golden quotes, and action it
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content
-- `yuque_list_repos` — List user's knowledge bases (to find the target repo for saving)
+- `yuque_list_books` — List user's knowledge bases (to find the target repo for saving)
 - `yuque_create_doc` — Create a new document (to save reading notes)
 - `yuque_search` — Search for existing reading notes to avoid duplicates
 
@@ -161,6 +161,6 @@ If the user doesn't want to save, just present the reading notes in the chat.
 | Document not found (404) | Inform user the document may have been deleted or the link is incorrect |
 | Permission denied (403) | Tell user they may lack permission to access this document |
 | Document content is empty | Inform user: "该文档内容为空，无法生成阅读笔记" |
-| Target repo not found when saving | List user's repos with `yuque_list_repos` and ask them to pick one |
+| Target repo not found when saving | List user's repos with `yuque_list_books` and ask them to pick one |
 | `yuque_create_doc` fails | Inform user the save failed, present the notes in chat instead |
 | Article is not text-based (e.g., pure images) | Inform user: "该文档主要是图片内容，无法提取文字进行分析" |

--- a/plugins/yuque-personal/skills/smart-summary/SKILL.md
+++ b/plugins/yuque-personal/skills/smart-summary/SKILL.md
@@ -24,7 +24,7 @@ Generate summaries at different granularity levels for any Yuque document or ent
 All tools are from the `yuque-mcp` server:
 
 - `yuque_get_doc` — Read full document content by slug/id
-- `yuque_get_repo` — Get knowledge base metadata
+- `yuque_get_book` — Get knowledge base metadata
 - `yuque_list_docs` — List all documents in a knowledge base
 - `yuque_get_toc` — Get the table of contents of a knowledge base
 

--- a/plugins/yuque-personal/skills/stale-detector/SKILL.md
+++ b/plugins/yuque-personal/skills/stale-detector/SKILL.md
@@ -23,7 +23,7 @@ Scan a Yuque knowledge base to discover documents that haven't been updated in a
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
+- `yuque_list_books` — List user's knowledge bases
 - `yuque_list_docs` — List all documents in a knowledge base with metadata
 - `yuque_get_doc` — Read document content for staleness analysis
 - `yuque_get_toc` — Get knowledge base structure
@@ -39,7 +39,7 @@ Extract `repo_id` (namespace) from the provided link or name.
 List all repos first:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 Parameters:
   user_id: "<user_id>"
 ```
@@ -190,7 +190,7 @@ These are suggestions only — do not take action without user confirmation.
 
 | Situation | Action |
 |-----------|--------|
-| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_repos` |
+| Knowledge base not found | Inform user and suggest listing their repos with `yuque_list_books` |
 | Knowledge base is empty | Inform user: "这个知识库目前没有文档，无需体检" |
 | `yuque_list_docs` returns error | Inform user of the issue, suggest checking the knowledge base link |
 | Too many documents (100+) | Analyze metadata for all, but only deep-read the top 10 stalest documents |

--- a/plugins/yuque-personal/skills/style-extract/SKILL.md
+++ b/plugins/yuque-personal/skills/style-extract/SKILL.md
@@ -24,8 +24,8 @@ Analyze your existing Yuque documents to extract your unique writing style — v
 
 All tools are from the `yuque-mcp` server:
 
-- `yuque_list_repos` — List user's knowledge bases
-- `yuque_get_repo_docs` — List documents in a knowledge base
+- `yuque_list_books` — List user's knowledge bases
+- `yuque_list_docs` — List documents in a knowledge base
 - `yuque_get_doc` — Read document content for style analysis
 - `yuque_search` — Find specific types of documents for analysis
 - `yuque_create_doc` — Save the style profile as a document
@@ -46,11 +46,11 @@ User specifies a knowledge base. Sample documents from it.
 If the user isn't sure, search for their most substantial documents:
 
 ```
-Tool: yuque_list_repos
+Tool: yuque_list_books
 ```
 
 ```
-Tool: yuque_get_repo_docs
+Tool: yuque_list_docs
 Parameters:
   repo_id: "<namespace>"
 ```

--- a/shared/mcp-config/AGENT-INSTALL.md
+++ b/shared/mcp-config/AGENT-INSTALL.md
@@ -201,17 +201,18 @@ echo "✅ All config files installed and token replaced"
 
 ---
 
-## Post-Installation: Available MCP Tools (25)
+## Post-Installation: Available MCP Tools (16)
 
 Once connected, the following tools are available to the AI agent:
 
 | Category | Tools |
 |----------|-------|
-| Document Management | `yuque_search`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc`, `yuque_delete_doc`, `yuque_get_doc_history` |
-| Knowledge Base | `yuque_list_repos`, `yuque_get_repo`, `yuque_create_repo`, `yuque_update_repo`, `yuque_delete_repo`, `yuque_get_toc` |
-| User & Group | `yuque_get_user`, `yuque_list_groups`, `yuque_get_group`, `yuque_list_group_repos` |
-| Collaboration | `yuque_list_comments`, `yuque_create_comment`, `yuque_delete_comment` |
-| Statistics | `yuque_get_doc_stats`, `yuque_get_repo_stats`, `yuque_get_group_stats`, `yuque_get_group_member_stats`, `yuque_get_trending_docs`, `yuque_get_active_members` |
+| User | `yuque_get_user` |
+| Search | `yuque_search` |
+| Books (知识库) | `yuque_list_books`, `yuque_get_book`, `yuque_create_book`, `yuque_update_book` |
+| Docs | `yuque_list_docs`, `yuque_get_doc`, `yuque_create_doc`, `yuque_update_doc` |
+| TOC | `yuque_get_toc`, `yuque_update_toc` |
+| Notes (小记) | `yuque_list_notes`, `yuque_get_note`, `yuque_create_note`, `yuque_update_note` |
 
 > **Note:** MCP-only installations provide tools but not skills. For skills, use the [Claude Code plugin](../../plugins/claude-code/) or [OpenCode plugin](../../plugins/opencode/).
 

--- a/website/src/components/McpQuickStart/McpQuickStart.tsx
+++ b/website/src/components/McpQuickStart/McpQuickStart.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react'
 import styles from './McpQuickStart.module.css'
 import CodeBlock from '../CodeBlock/CodeBlock'
 
-type Client = 'cursor' | 'vscode' | 'windsurf' | 'claude-desktop' | 'trae' | 'qoder' | 'cline'
+type Client = 'cursor' | 'vscode' | 'windsurf' | 'claude-desktop' | 'claude-code' | 'codex' | 'trae' | 'qoder' | 'cline'
 
 interface ClientInfo {
   id: Client
   label: string
   flag: string
+  /** If true, this client uses its own CLI command instead of `npx yuque-mcp install` */
+  customInstall?: boolean
 }
 
 const clients: ClientInfo[] = [
@@ -15,6 +17,8 @@ const clients: ClientInfo[] = [
   { id: 'vscode', label: 'GitHub Copilot', flag: 'vscode' },
   { id: 'windsurf', label: 'Windsurf', flag: 'windsurf' },
   { id: 'claude-desktop', label: 'Claude Desktop', flag: 'claude-desktop' },
+  { id: 'claude-code', label: 'Claude Code', flag: 'claude-code', customInstall: true },
+  { id: 'codex', label: 'Codex', flag: 'codex', customInstall: true },
   { id: 'trae', label: 'Trae', flag: 'trae' },
   { id: 'qoder', label: 'Qoder', flag: 'qoder' },
   { id: 'cline', label: 'Cline', flag: 'cline' },
@@ -116,33 +120,106 @@ function McpQuickStart() {
 
       {/* Install Options */}
       <div className={styles.installOptions}>
-        {/* Option 1: One-click */}
-        <div className={styles.installOption}>
-          <div className={styles.optionHeader}>
-            <span className={`${styles.optionBadge} ${styles.optionBadgeRecommended}`}>推荐</span>
-            <h3 className={styles.optionTitle}>一键安装</h3>
-          </div>
-          <p className={styles.optionDesc}>
-            自动为 {currentClient.label} 配置语雀 MCP Server，替换 <code className={styles.codeHighlight}>YOUR_TOKEN</code> 为你的语雀 Token。
-          </p>
-          <CodeBlock>
-            npx yuque-mcp install --client={currentClient.flag} --token=<span className={styles.codeHighlight}>YOUR_TOKEN</span>
-          </CodeBlock>
-        </div>
+        {currentClient.customInstall && currentClient.id === 'claude-code' ? (
+          <>
+            {/* Claude Code - direct MCP config */}
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeRecommended}`}>推荐</span>
+                <h3 className={styles.optionTitle}>一键添加 MCP Server</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                使用 Claude Code 内置的 MCP 管理命令，直接添加语雀 MCP Server。
+              </p>
+              <CodeBlock>
+                claude mcp add yuque-mcp -- npx -y yuque-mcp --token=<span className={styles.codeHighlight}>YOUR_TOKEN</span>
+              </CodeBlock>
+            </div>
 
-        <div className={styles.optionDivider} />
+            <div className={styles.optionDivider} />
 
-        {/* Option 2: Interactive */}
-        <div className={styles.installOption}>
-          <div className={styles.optionHeader}>
-            <span className={`${styles.optionBadge} ${styles.optionBadgeAlt}`}>交互式</span>
-            <h3 className={styles.optionTitle}>交互式引导</h3>
-          </div>
-          <p className={styles.optionDesc}>
-            通过问答式引导完成安装，适合不确定配置细节的用户。
-          </p>
-          <CodeBlock>npx yuque-mcp setup</CodeBlock>
-        </div>
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeAlt}`}>环境变量</span>
+                <h3 className={styles.optionTitle}>通过环境变量配置</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                先设置环境变量，再添加 MCP Server，Token 不会出现在命令历史中。
+              </p>
+              <CodeBlock>
+                <span className={styles.codeComment}># 设置环境变量</span>{'\n'}
+                export YUQUE_PERSONAL_TOKEN=<span className={styles.codeHighlight}>YOUR_TOKEN</span>{'\n'}
+                <span className={styles.codeComment}># 添加 MCP Server</span>{'\n'}
+                claude mcp add yuque-mcp -- npx -y yuque-mcp
+              </CodeBlock>
+            </div>
+          </>
+        ) : currentClient.customInstall && currentClient.id === 'codex' ? (
+          <>
+            {/* Codex - CLI based config */}
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeRecommended}`}>推荐</span>
+                <h3 className={styles.optionTitle}>一键添加 MCP Server</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                使用 Codex 内置的 MCP 管理命令，直接添加语雀 MCP Server。
+              </p>
+              <CodeBlock>
+                codex mcp add yuque --env YUQUE_PERSONAL_TOKEN=<span className={styles.codeHighlight}>YOUR_TOKEN</span> -- npx -y yuque-mcp
+              </CodeBlock>
+            </div>
+
+            <div className={styles.optionDivider} />
+
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeAlt}`}>手动配置</span>
+                <h3 className={styles.optionTitle}>编辑 config.toml</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                在 <code className={styles.codeHighlight}>~/.codex/config.toml</code> 中添加以下配置：
+              </p>
+              <CodeBlock>
+                <span className={styles.codeComment}>[mcp_servers.yuque]</span>{'\n'}
+                command = "npx"{'\n'}
+                args = ["-y", "yuque-mcp"]{'\n'}
+                {'\n'}
+                <span className={styles.codeComment}>[mcp_servers.yuque.env]</span>{'\n'}
+                YUQUE_PERSONAL_TOKEN = "<span className={styles.codeHighlight}>YOUR_TOKEN</span>"
+              </CodeBlock>
+            </div>
+          </>
+        ) : (
+          <>
+            {/* Generic clients - npx yuque-mcp install */}
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeRecommended}`}>推荐</span>
+                <h3 className={styles.optionTitle}>一键安装</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                自动为 {currentClient.label} 配置语雀 MCP Server，替换 <code className={styles.codeHighlight}>YOUR_TOKEN</code> 为你的语雀 Token。
+              </p>
+              <CodeBlock>
+                npx yuque-mcp install --client={currentClient.flag} --token=<span className={styles.codeHighlight}>YOUR_TOKEN</span>
+              </CodeBlock>
+            </div>
+
+            <div className={styles.optionDivider} />
+
+            <div className={styles.installOption}>
+              <div className={styles.optionHeader}>
+                <span className={`${styles.optionBadge} ${styles.optionBadgeAlt}`}>交互式</span>
+                <h3 className={styles.optionTitle}>交互式引导</h3>
+              </div>
+              <p className={styles.optionDesc}>
+                通过问答式引导完成安装，适合不确定配置细节的用户。
+              </p>
+              <CodeBlock>npx yuque-mcp setup</CodeBlock>
+            </div>
+          </>
+        )}
       </div>
     </section>
   )

--- a/website/src/components/McpTools/McpTools.tsx
+++ b/website/src/components/McpTools/McpTools.tsx
@@ -20,7 +20,6 @@ const categories: Category[] = [
     icon: '👤',
     tools: [
       { name: 'yuque_get_user', desc: '获取当前用户信息（头像、昵称、个人简介等）' },
-      { name: 'yuque_list_groups', desc: '列出用户加入的所有团队/组织' },
     ],
   },
   {
@@ -32,14 +31,14 @@ const categories: Category[] = [
     ],
   },
   {
-    key: 'repos',
-    label: 'Repos',
+    key: 'books',
+    label: 'Books',
     icon: '📚',
     tools: [
-      { name: 'yuque_list_repos', desc: '列出指定团队或用户的所有知识库' },
-      { name: 'yuque_get_repo', desc: '获取知识库详情（名称、描述、文档数等）' },
-      { name: 'yuque_create_repo', desc: '创建新知识库' },
-      { name: 'yuque_update_repo', desc: '更新知识库信息' },
+      { name: 'yuque_list_books', desc: '列出当前用户的所有知识库' },
+      { name: 'yuque_get_book', desc: '获取知识库详情（名称、描述、文档数等）' },
+      { name: 'yuque_create_book', desc: '创建新知识库' },
+      { name: 'yuque_update_book', desc: '更新知识库信息' },
     ],
   },
   {
@@ -48,7 +47,7 @@ const categories: Category[] = [
     icon: '📄',
     tools: [
       { name: 'yuque_list_docs', desc: '列出知识库中的所有文档' },
-      { name: 'yuque_get_doc', desc: '获取文档详情和内容（Markdown/HTML）' },
+      { name: 'yuque_get_doc', desc: '获取文档详情和完整内容' },
       { name: 'yuque_create_doc', desc: '创建新文档' },
       { name: 'yuque_update_doc', desc: '更新文档内容或属性' },
     ],
@@ -63,15 +62,6 @@ const categories: Category[] = [
     ],
   },
   {
-    key: 'versions',
-    label: 'Versions',
-    icon: '🕐',
-    tools: [
-      { name: 'yuque_list_doc_versions', desc: '列出文档的所有历史版本' },
-      { name: 'yuque_get_doc_version', desc: '获取文档某个历史版本的内容' },
-    ],
-  },
-  {
     key: 'notes',
     label: 'Notes',
     icon: '📝',
@@ -80,14 +70,6 @@ const categories: Category[] = [
       { name: 'yuque_get_note', desc: '获取小记详情' },
       { name: 'yuque_create_note', desc: '创建新小记' },
       { name: 'yuque_update_note', desc: '更新小记内容' },
-    ],
-  },
-  {
-    key: 'utility',
-    label: 'Utility',
-    icon: '🔧',
-    tools: [
-      { name: 'yuque_hello', desc: '连接测试，验证 Token 是否有效' },
     ],
   },
 ]
@@ -100,7 +82,7 @@ function McpTools() {
     <section className={styles.section}>
       <p className={styles.sectionLabel}>MCP Tools</p>
       <div className={styles.titleRow}>
-        <h2 className={styles.sectionTitle}>20 个标准化工具，覆盖语雀全部核心能力</h2>
+        <h2 className={styles.sectionTitle}>16 个标准化工具，覆盖语雀全部核心能力</h2>
         <div className={styles.titleLinks}>
           <a
             className={styles.externalLink}

--- a/website/src/components/Modules/Modules.tsx
+++ b/website/src/components/Modules/Modules.tsx
@@ -5,7 +5,7 @@ const modules = [
     icon: '🔌',
     title: 'MCP Server',
     desc: '底层连接层，为 AI 助手提供标准化的语雀 API 接口，让任何 MCP 兼容客户端都能操作语雀。',
-    meta: '25 个标准化 Tools',
+    meta: '16 个标准化 Tools',
   },
   {
     icon: '⚡',
@@ -17,7 +17,7 @@ const modules = [
     icon: '🧩',
     title: 'Plugin',
     desc: '一键集成 MCP + Skills，让 AI 助手开箱即用地操作语雀。支持 Claude Code、OpenClaw 等客户端。',
-    meta: '25 Tools + 14 Skills',
+    meta: '16 Tools + 14 Skills',
   },
 ]
 

--- a/website/src/components/Skills/Skills.tsx
+++ b/website/src/components/Skills/Skills.tsx
@@ -8,7 +8,7 @@ const personalSkills = [
     desc: '阅读文章后自动提取核心观点、金句、行动项，生成结构化阅读笔记。',
     tags: ['get_doc', 'create_doc', 'search'],
     category: '📥 输入',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/reading-digest',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/reading-digest',
   },
   {
     icon: '💡',
@@ -16,7 +16,7 @@ const personalSkills = [
     desc: '随时记录灵感和想法，定期自动归类整理，合并成结构化的主题笔记。',
     tags: ['search', 'create_doc', 'update_doc'],
     category: '📥 输入',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/daily-capture',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/daily-capture',
   },
   // 🧠 加工
   {
@@ -25,23 +25,23 @@ const personalSkills = [
     desc: '把粗糙笔记打磨成高质量文档，补充结构、优化表达、改善排版。',
     tags: ['get_doc', 'update_doc'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/note-refine',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/note-refine',
   },
   {
     icon: '🕸️',
     title: '知识关联',
     desc: '分析知识库文档间的隐藏联系，建议交叉引用链接，构建知识网络。',
-    tags: ['get_repo_docs', 'get_doc', 'update_doc', 'search'],
+    tags: ['list_docs', 'get_doc', 'update_doc', 'search'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/knowledge-connect',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/knowledge-connect',
   },
   {
     icon: '✍️',
     title: '风格提取',
     desc: '分析你的写作风格，生成风格画像，帮你保持一致的文风写新内容。',
-    tags: ['get_repo_docs', 'get_doc', 'create_doc'],
+    tags: ['list_docs', 'get_doc', 'create_doc'],
     category: '🧠 加工',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/style-extract',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/style-extract',
   },
   // 📤 输出
   {
@@ -50,24 +50,24 @@ const personalSkills = [
     desc: '自然语言搜索个人知识库，秒找到并总结关键内容。',
     tags: ['search', 'get_doc'],
     category: '📤 输出',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/smart-search',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/smart-search',
   },
   {
     icon: '📋',
     title: '智能摘要',
     desc: '对任意文档或知识库生成不同粒度的摘要：一句话、要点、详细。',
-    tags: ['get_doc', 'get_repo_docs'],
+    tags: ['get_doc', 'list_docs'],
     category: '📤 输出',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/smart-summary',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/smart-summary',
   },
   // 🔄 维护
   {
     icon: '🔎',
     title: '过期检测',
     desc: '扫描知识库发现过期文档，生成健康报告，建议更新或归档。',
-    tags: ['get_repo_docs', 'get_doc', 'search'],
+    tags: ['list_docs', 'get_doc', 'search'],
     category: '🔄 维护',
-    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/claude-code/personal/skills/stale-detector',
+    link: 'https://github.com/yuque/yuque-ecosystem/tree/main/plugins/yuque-personal/skills/stale-detector',
   },
 ]
 


### PR DESCRIPTION
## Summary

This PR fixes three website-related issues in a single changeset.

### Issue #61: Feature Request link 404
- **Problem:** The issue template config linked to `/discussions/categories/ideas` and `/discussions/categories/q-a`, but Discussions is not enabled on this repo (`has_discussions: false`).
- **Fix:** Created a proper `feature_request.yml` issue template and updated `config.yml` to remove broken Discussions links. Feature requests now go through the standard issue form.

### Issue #59: Website shows deprecated tools
- **Problem:** The website listed 20 MCP tools, but yuque-mcp-server was trimmed to 16 tools (PR #42).
- **Fix:** Updated `McpTools.tsx` to match the current tool list:
  - Removed: `yuque_list_groups`, `yuque_hello`, `yuque_list_doc_versions`, `yuque_get_doc_version`
  - Renamed: `repos` category → `books` (matching API naming: `yuque_list_books`, `yuque_get_book`, etc.)
  - Removed: Versions and Utility categories
  - Updated tool count: 20 → 16

### Issue #62: Missing Claude Code and Codex install guides
- **Problem:** Quick Start only supported IDE-based clients via `npx yuque-mcp install`, missing Claude Code (direct MCP) and OpenAI Codex.
- **Fix:** Added two new client tabs in `McpQuickStart.tsx`:
  - **Claude Code**: `claude mcp add yuque-mcp -- npx -y yuque-mcp --token=YOUR_TOKEN` (with env var alternative)
  - **Codex**: `codex mcp add yuque --env YUQUE_PERSONAL_TOKEN=YOUR_TOKEN -- npx -y yuque-mcp` (with config.toml alternative)

### Files Changed
- `.github/ISSUE_TEMPLATE/config.yml` — Removed broken Discussions links
- `.github/ISSUE_TEMPLATE/feature_request.yml` — New feature request template
- `website/src/components/McpTools/McpTools.tsx` — Updated tool list (20→16)
- `website/src/components/McpQuickStart/McpQuickStart.tsx` — Added Claude Code & Codex tabs

### Verification
- `npm run build` passes successfully
- All install commands verified against upstream documentation

Closes #59, Closes #61, Closes #62