### PR TITLE
fix: correct malformed JSON in yuque-personal/group plugin manifests

### DIFF
--- a/plugins/yuque-group/.claude-plugin/plugin.json
+++ b/plugins/yuque-group/.claude-plugin/plugin.json
@@ -3,8 +3,6 @@
   "description": "语雀团队版 — 团队知识库 AI 集成，16 MCP Tools + 6 Skills",
   "version": "1.0.1",
   "author": {
-      "name": "yuque"
-    },
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",

--- a/plugins/yuque-personal/.claude-plugin/plugin.json
+++ b/plugins/yuque-personal/.claude-plugin/plugin.json
@@ -3,8 +3,6 @@
   "description": "语雀个人版 — 个人知识库 AI 集成，16 MCP Tools + 8 Skills",
   "version": "1.0.1",
   "author": {
-      "name": "yuque"
-    },
     "name": "yuque"
   },
   "homepage": "https://yuque.github.io/yuque-ecosystem/",


### PR DESCRIPTION
## Problem

`plugins/yuque-personal/.claude-plugin/plugin.json` and `plugins/yuque-group/.claude-plugin/plugin.json` both contain malformed JSON: an extra `"name": "yuque"` key plus an unmatched closing brace after the `author` block. Example (yuque-personal):

```json
"author": {
    "name": "yuque"
  },
  "name": "yuque"        // ← orphan key
},                        // ← extra closing brace, terminates root object early
"homepage": "...",        // ← now outside the JSON object → invalid
```

## Reproduction

```bash
curl -s https://raw.githubusercontent.com/yuque/yuque-ecosystem/main/plugins/yuque-personal/.claude-plugin/plugin.json | python3 -m json.tool
# Extra data: line 9 column 4 (char 182)

claude plugin marketplace add yuque/yuque-ecosystem
claude plugin install yuque-personal@yuque
# ✘ Failed to install plugin "yuque-personal@yuque": Plugin … has a corrupt manifest file …
# JSON parse error: JSON Parse error: Unable to parse JSON string
```

`yuque-group` fails identically.

## Fix

Remove the orphan `"name"` key and the extra closing brace, leaving a single well-formed `author` object.

```diff
   "author": {
-      "name": "yuque"
-    },
-    "name": "yuque"
+    "name": "yuque"
   },
```

After the fix, `python3 -m json.tool` parses cleanly and `claude plugin install yuque-personal@yuque` / `yuque-group@yuque` both succeed.

## Verification

```bash
python3 -c "import json; json.load(open('plugins/yuque-personal/.claude-plugin/plugin.json'))"
python3 -c "import json; json.load(open('plugins/yuque-group/.claude-plugin/plugin.json'))"
# both return without error
```
